### PR TITLE
Add yaml version tag

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -1,5 +1,5 @@
----
 %YAML 1.2
+---
 # Types:
 #     - Nativ datatypes: text, string (text with maxLength=256), number, boolean, JSON
 #     - HTMLStrict: A string with HTML content.

--- a/models.yml
+++ b/models.yml
@@ -1,4 +1,5 @@
 ---
+%YAML 1.2
 # Types:
 #     - Nativ datatypes: text, string (text with maxLength=256), number, boolean, JSON
 #     - HTMLStrict: A string with HTML content.


### PR DESCRIPTION
With 98de71df06d9940f575334c9c2e42ceb7e41c64c anchors were introduced. For this to work with the golang yaml decoder the yaml version needs to be specified.