### PR TITLE
Add dev files & setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/dev"
     schedule:
       interval: "daily"
     assignees:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,6 +13,9 @@ jobs:
   validate-models:
     name: CI
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dev/
 
     steps:
     - uses: actions/checkout@v4
@@ -23,7 +26,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install requirements
-      run: pip install -r models_validator/requirements.txt
+      run: pip install -r requirements.txt
 
     - name: Check black
       if: always()

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   validate-models:
-    name: Validate models.yml
+    name: CI
     runs-on: ubuntu-latest
 
     steps:
@@ -25,5 +25,26 @@ jobs:
     - name: Install requirements
       run: pip install -r models_validator/requirements.txt
 
+    - name: Check black
+      if: always()
+      run: make check-black
+
+    - name: Check isort
+      if: always()
+      run: make check-isort
+
+    - name: Check flake8
+      if: always()
+      run: make flake8
+
+    - name: Check mypy
+      if: always()
+      run: make mypy
+
+    - name: Check pyupgrade
+      if: always()
+      run: make pyupgrade
+
     - name: Validate models.yml
-      run: python models_validator/validate.py models.yml
+      if: always()
+      run: make validate-models

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10.13-slim-bookworm
+
+RUN apt-get update && apt-get install --yes make bash-completion
+
+WORKDIR /app/dev/
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+STOPSIGNAL SIGKILL
+CMD sleep infinity

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,42 @@
+# Commands inside the container
+
+all: pyupgrade black autoflake isort flake8 mypy
+
+pyupgrade:
+	pyupgrade --py310-plus --exit-zero-even-if-changed $$(find . -name '*.py')
+
+check-pyupgrade:
+	pyupgrade --py310-plus $$(find . -name '*.py')
+
+black:
+	black src/
+
+check-black:
+	black --check --diff src/
+
+autoflake:
+	autoflake src/
+
+isort:
+	isort src/
+
+check-isort:
+	isort --check-only --diff src/
+
+flake8:
+	flake8 src/
+
+mypy:
+	mypy src/
+
+validate-models:
+	python src/validate.py
+
+# Docker manage commands
+
+run-dev:
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose up -d --build
+	docker-compose exec models bash --rcfile /etc/bash_completion
+
+stop-dev:
+	docker-compose down

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+    models:
+        build: .
+        user: $USER_ID:$GROUP_ID
+        volumes:
+            - ..:/app
+        depends_on:
+            - postgres
+        networks:
+            - postgres
+    postgres:
+        image: postgres:15
+        environment:
+            - POSTGRES_USER=openslides
+            - POSTGRES_PASSWORD=openslides
+            - POSTGRES_DB=openslides
+        networks:
+            - postgres
+networks:
+    postgres:

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,13 @@
+autoflake==2.2.1
+black==24.1.1
+flake8==7.0.0
+isort==5.13.2
+mypy==1.8.0
+pytest==8.0.0
+pyupgrade==3.15.0
+pyyaml==6.0.1
+simplejson==3.19.2
+
+# typing
+types-PyYAML==6.0.12.12
+types-simplejson==3.19.0.2

--- a/dev/setup.cfg
+++ b/dev/setup.cfg
@@ -1,0 +1,19 @@
+[autoflake]
+verbose = true
+in-place = true
+remove-all-unused-imports = true
+ignore-init-module-imports = true
+recursive = true
+
+[isort]
+include_trailing_comma = true
+multi_line_output = 3
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[flake8]
+extend-ignore = E203,E501
+
+[mypy]
+disallow_untyped_defs = true

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from pathlib import Path
 from typing import Any, cast
 
 import simplejson as json
@@ -17,9 +18,7 @@ COLLECTIONFIELD_REGEX = re.compile(f"^{_collection_regex}{KEYSEPARATOR}{_field_r
 DECIMAL_REGEX = re.compile(r"^-?(\d|[1-9]\d+)\.\d{6}$")
 COLOR_REGEX = re.compile(r"^#[0-9a-f]{6}$")
 
-DEFAULT_FILES = [
-    "../models.yml",
-]
+DEFAULT_FILES = [str((Path(__file__).parent / ".." / ".." / "models.yml").resolve())]
 
 RELATION_TYPES = (
     "relation",

--- a/models_validator/requirements.txt
+++ b/models_validator/requirements.txt
@@ -1,3 +1,0 @@
-pyyaml==6.0.1
-simplejson==3.19.2
-types-PyYAML==6.0.12.12


### PR DESCRIPTION
Adds a docker-compose setup to the repo, together with all formatting and linting tools used in the backend as well as automatic scripts and checks for them. Some notes:
- I moved everything dev-related into a `dev` folder. For this to make sense (as everything in this repo is dev-specific, if you look at it that way), I interpreted the actual usage of the repo (holding the meta `*.yml` files) as its "productive" purpose. Then, everything related to testing/maintaining these files is "dev" stuff. This leads to a nice separation of intents and a cleaner overall structure, IMO.
- There is no simple way to use multiple `setup.cfg` (or other config files) in one call to some python tool (e.g. isort). Therefore, I resorted to copying the config from the backend. If they were to diverge, this could lead to some annoying behaviour were the meta repo wants the files to be formatted in some way and the backend in the other. I deemed this risk to be pretty low as we do not change the `setup.cfg` often, but it's still something to keep in mind if it ever comes up.
- I also copied the dependencies from the backend. This is somewhat redundant, as it would be easier to just include the requirements file from this repo in the backends requirements file. I decided against this, however, as the requirements are automatically kept up-to-date via dependabot, which means the backend and the meta repo will get updated simultaniously. If we incuded the requirements file from here in the backend, the backend would get no automatic updates, which might lead to some problems when one wants to update the meta repo's hash in the backend for some unrelated feature. This could be solved via another GitHub action which automatically updates the meta repo in the backend after some dependency changed, but for now I decided against this.

@r-peschke With this setup, it should be easily possible to add a `/dev/tests` folder which includes all tests and can be executed via `pytest`. As the setup is never used for anything else, I think we can just hardcode the postgres access data (host, port, user, db, password) in the test code and don't need to make it configurable via some env vars.