### PR TITLE
Fix searches including users with stucture levels failing

### DIFF
--- a/search.yml
+++ b/search.yml
@@ -115,7 +115,7 @@ motion:
             id: null
             number: null
             structure_level_ids:
-              type: relation
+              type: relation-list
               collection: structure_level
               fields:
                 id: null


### PR DESCRIPTION
If a search result is containing a user with a structure level the search is currently failing because the relation type is wrong. 