### PR TITLE
Add action to automatically close issues

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,53 @@
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - "feature/*"
+      - "staging/4*"
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
+    steps:
+      - name: Generate access token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - uses: octokit/graphql-action@v2.x
+        id: get-issues
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          query: |
+            query getLinkedIssues($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  closingIssuesReferences(first: 100) {
+                    nodes {
+                      number
+                      repository {
+                        nameWithOwner
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables: |
+            owner: ${{ github.event.repository.owner.name }}
+            repo: ${{ github.event.repository.name }}
+            number: ${{ github.event.pull_request.number }}
+
+      - name: Close issues
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          issue_data=($(echo "${{ steps.get-issues.outputs.data }}" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | .number,.repository.nameWithOwner'))
+          for i in $(seq 1 2 ${#issue_data[@]}); do
+            gh issue close ${issue_data[i-1]} -r ${issue_data[i]}
+          done

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -4,7 +4,6 @@ on:
       - closed
     branches:
       - "feature/*"
-      - "staging/4*"
 
 jobs:
   close-issue:
@@ -47,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          issue_data=($(echo "${{ steps.get-issues.outputs.data }}" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes[] | .number,.repository.nameWithOwner'))
-          for i in $(seq 1 2 ${#issue_data[@]}); do
-            gh issue close ${issue_data[i-1]} -r ${issue_data[i]}
-          done
+          issue_data="$(echo "${{ steps.get-issues.outputs.data }}" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[] | [.number,.repository.nameWithOwner] | @tsv')"
+          while read number nameWithOwner; do
+            gh issue close "$number" -r "$nameWithOwner"
+          done <<< "$issue_data"

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -47,6 +47,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           issue_data="$(echo "${{ steps.get-issues.outputs.data }}" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[] | [.number,.repository.nameWithOwner] | @tsv')"
-          while read number nameWithOwner; do
+          echo "$issue_data" | while read number nameWithOwner; do
             gh issue close "$number" -r "$nameWithOwner"
-          done <<< "$issue_data"
+          done


### PR DESCRIPTION
This action runs upon merging a PR and fetches all linked issues (whether by body or through the side bar, thankfully the graphql API returns both). It then iterates the fetched data using `jq` and closes the issues through the Github CLI.