### PR TITLE
Cherry pick backend PR 2243

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -2605,11 +2605,13 @@ motion:
   editor_ids:
     type: relation-list
     to: motion_editor/motion_id
+    on_delete: CASCADE
     equal_fields: meeting_id
     restriction_mode: B
   working_group_speaker_ids:
     type: relation-list
     to: motion_working_group_speaker/motion_id
+    on_delete: CASCADE
     equal_fields: meeting_id
     restriction_mode: B
   poll_ids:


### PR DESCRIPTION
8a52cbe8 in the backend (PR https://github.com/OpenSlides/openslides-backend/pull/2243) is to
be cherry picked from `main` into `staging/4.1.3`.

Therefore I first cherry-pick 7379494 containing the remaining changes needed in this repo.
Afterwards I will update the meta references in all relevant services including the backend.