### PR TITLE
use sql only in relaton fields

### DIFF
--- a/dev/tests/base.py
+++ b/dev/tests/base.py
@@ -84,13 +84,13 @@ class BaseTestCase(TestCase):
         """ do something like setting initial_data.json"""
         with cls.db_connection.transaction():
             with cls.db_connection.cursor() as curs:
-                cls.theme1_id = DbUtils.insert_wrapper(curs, "themeT", {
+                cls.theme1_id = DbUtils.insert_wrapper(curs, "theme_t", {
                     "name": "OpenSlides Blue",
                     "accent_500": int("0x2196f3", 16),
                     "primary_500": int("0x317796", 16),
                     "warn_500": int("0xf06400", 16),
                 })
-                cls.organization_id = DbUtils.insert_wrapper(curs, "organizationT", {
+                cls.organization_id = DbUtils.insert_wrapper(curs, "organization_t", {
                     "name": "Test Organization",
                     "legal_notice": "<a href=\"http://www.openslides.org\">OpenSlides</a> is a free web based presentation and assembly system for visualizing and controlling agenda, motions and elections of an assembly.",
                     "login_text": "Good Morning!",
@@ -120,7 +120,7 @@ class BaseTestCase(TestCase):
                         "is_physical_person": "is_person"
                     })
                 })
-                cls.user1_id = DbUtils.insert_wrapper(curs, "userT", {
+                cls.user1_id = DbUtils.insert_wrapper(curs, "user_t", {
                     "username": "admin",
                     "last_name": "Administrator",
                     "is_active": True,
@@ -132,7 +132,7 @@ class BaseTestCase(TestCase):
                     "default_vote_weight": "1.000000",
                     "organization_management_level": "superadmin",
                 })
-                cls.committee1_id = DbUtils.insert_wrapper(curs, "committeeT", {
+                cls.committee1_id = DbUtils.insert_wrapper(curs, "committee_t", {
                     "name": "Default committee",
                     "description": "Add description here",
                 })
@@ -143,7 +143,7 @@ class BaseTestCase(TestCase):
                 cls.groupM1_staff_id = result_ids["staff_group_id"]
                 cls.simple_workflowM1_id = result_ids["simple_workflow_id"]
                 cls.complex_workflowM1_id = result_ids["complex_workflow_id"]
-                curs.execute("UPDATE committeeT SET default_meeting_id = %s where id = %s;", (result_ids["meeting_id"], cls.committee1_id))
+                curs.execute("UPDATE committee_t SET default_meeting_id = %s where id = %s;", (result_ids["meeting_id"], cls.committee1_id))
 
     @classmethod
     def create_meeting(cls, curs: psycopg.Cursor, committee_id: int, meeting_id: int = 0, ) -> None:
@@ -161,14 +161,14 @@ class BaseTestCase(TestCase):
         """
         result = {}
         if meeting_id:
-            sequence_name = curs.execute("select * from pg_get_serial_sequence('meetingT', 'id');").fetchone()["pg_get_serial_sequence"]
+            sequence_name = curs.execute("select * from pg_get_serial_sequence('meeting_t', 'id');").fetchone()["pg_get_serial_sequence"]
             last_value = curs.execute(f"select last_value from {sequence_name};").fetchone()["last_value"]
             if last_value >= meeting_id:
                 raise ValueError(f"meeting_id {meeting_id} is not available, last_value in sequence {sequence_name} is {last_value}")
-            result["meeting_id"] = curs.execute("select setval(pg_get_serial_sequence('meetingT', 'id'), %s);", (meeting_id,)).fetchone()["setval"]
+            result["meeting_id"] = curs.execute("select setval(pg_get_serial_sequence('meeting_t', 'id'), %s);", (meeting_id,)).fetchone()["setval"]
         else:
-            result["meeting_id"] = curs.execute("select nextval(pg_get_serial_sequence('meetingT', 'id')) as id_;").fetchone()["id_"]
-        (result["default_group_id"], result["admin_group_id"], result["staff_group_id"]) = DbUtils.insert_many_wrapper(curs, "groupT", [
+            result["meeting_id"] = curs.execute("select nextval(pg_get_serial_sequence('meeting_t', 'id')) as id_;").fetchone()["id_"]
+        (result["default_group_id"], result["admin_group_id"], result["staff_group_id"]) = DbUtils.insert_many_wrapper(curs, "group_t", [
             {
                 "name": "Default",
                 "permissions": [
@@ -211,7 +211,7 @@ class BaseTestCase(TestCase):
                 "meeting_id": result["meeting_id"]
             }
         ])
-        (result["default_projector_id"], result["secondary_projector_id"]) = DbUtils.insert_many_wrapper(curs, "projectorT", [
+        (result["default_projector_id"], result["secondary_projector_id"]) = DbUtils.insert_many_wrapper(curs, "projector_t", [
             {
                 "name": "Default projector",
                 "is_internal": False,
@@ -271,9 +271,9 @@ class BaseTestCase(TestCase):
                 "meeting_id": result["meeting_id"]
             }
         ])
-        result["simple_workflow_id"] = curs.execute("select nextval(pg_get_serial_sequence('motion_workflowT', 'id')) as new_id;").fetchone()["new_id"]
-        result["complex_workflow_id"] = curs.execute("select nextval(pg_get_serial_sequence('motion_workflowT', 'id')) as new_id;").fetchone()["new_id"]
-        wf_m1_simple_motion_state_ids = DbUtils.insert_many_wrapper(curs, "motion_stateT", [
+        result["simple_workflow_id"] = curs.execute("select nextval(pg_get_serial_sequence('motion_workflow_t', 'id')) as new_id;").fetchone()["new_id"]
+        result["complex_workflow_id"] = curs.execute("select nextval(pg_get_serial_sequence('motion_workflow_t', 'id')) as new_id;").fetchone()["new_id"]
+        wf_m1_simple_motion_state_ids = DbUtils.insert_many_wrapper(curs, "motion_state_t", [
             {
                 "name": "submitted",
                 "weight": 1,
@@ -347,7 +347,7 @@ class BaseTestCase(TestCase):
             },
         ])
         wf_m1_simple_first_state_id = wf_m1_simple_motion_state_ids[0]
-        wf_m1_complex_motion_state_ids = DbUtils.insert_many_wrapper(curs, "motion_stateT", [
+        wf_m1_complex_motion_state_ids = DbUtils.insert_many_wrapper(curs, "motion_state_t", [
             {
                 "name": "in progress",
                 "weight": 5,
@@ -545,7 +545,7 @@ class BaseTestCase(TestCase):
         ])
         wf_m1_complex_first_state_id = wf_m1_complex_motion_state_ids[0]
 
-        DbUtils.insert_many_wrapper(curs, "nm_motion_state_next_state_ids_motion_stateT",
+        DbUtils.insert_many_wrapper(curs, "nm_motion_state_next_state_ids_motion_state_t",
             [
                 {"next_state_id": wf_m1_simple_motion_state_ids[1], "previous_state_id": wf_m1_simple_motion_state_ids[0]},
                 {"next_state_id": wf_m1_simple_motion_state_ids[2], "previous_state_id": wf_m1_simple_motion_state_ids[0]},
@@ -563,7 +563,7 @@ class BaseTestCase(TestCase):
                 {"next_state_id": wf_m1_complex_motion_state_ids[8], "previous_state_id": wf_m1_complex_motion_state_ids[2]},
                 {"next_state_id": wf_m1_complex_motion_state_ids[9], "previous_state_id": wf_m1_complex_motion_state_ids[2]},
             ], returning='')
-        assert [result["simple_workflow_id"], result["complex_workflow_id"]] == DbUtils.insert_many_wrapper(curs, "motion_workflowT",
+        assert [result["simple_workflow_id"], result["complex_workflow_id"]] == DbUtils.insert_many_wrapper(curs, "motion_workflow_t",
             [
                 {
                     "id": result["simple_workflow_id"],
@@ -581,7 +581,7 @@ class BaseTestCase(TestCase):
                 }
             ]
         )
-        assert result["meeting_id"] == DbUtils.insert_wrapper(curs, "meetingT", {
+        assert result["meeting_id"] == DbUtils.insert_wrapper(curs, "meeting_t", {
                     "id": result["meeting_id"],
                     "name": "OpenSlides Demo",
                     "is_active_in_organization_id": cls.organization_id,

--- a/dev/tests/test_generic_relations.py
+++ b/dev/tests/test_generic_relations.py
@@ -60,7 +60,7 @@ class Relations(BaseTestCase):
                 assert group_staff_row["name"] == "Staff"
                 assert group_staff_row["meeting_id"] == self.meeting1_id
                 assert group_staff_row["default_group_for_meeting_id"] == None
-                curs.execute(sql.SQL("UPDATE meetingT SET default_group_id = %s where id = %s;"), (group_staff_row["id"], self.meeting1_id))
+                curs.execute(sql.SQL("UPDATE meeting_t SET default_group_id = %s where id = %s;"), (group_staff_row["id"], self.meeting1_id))
             # assert new and old data
             meeting_row = DbUtils.select_id_wrapper(curs, "meeting", self.meeting1_id, ["default_group_id"])
             assert meeting_row["default_group_id"] == group_staff_row["id"]
@@ -77,7 +77,7 @@ class Relations(BaseTestCase):
             with pytest.raises(psycopg.errors.RaiseException) as e:
                 projector_id = curs.execute("SELECT id from projector where used_as_default_projector_for_topic_in_meeting_id = %s", (self.meeting1_id,)).fetchone()['id']
                 with self.db_connection.transaction():
-                    curs.execute(sql.SQL("UPDATE projectorT SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_id,))
+                    curs.execute(sql.SQL("UPDATE projector_t SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_id,))
         assert 'Exception: NOT NULL CONSTRAINT VIOLATED for meeting.default_projector_topic_ids' in str(e)
 
     def test_one_to_many_1t_ntR_update_okay(self) -> None:
@@ -85,8 +85,8 @@ class Relations(BaseTestCase):
         with self.db_connection.cursor() as curs:
             projector_ids = curs.execute("SELECT id from projector where meeting_id = %s", (self.meeting1_id,)).fetchall()
             with self.db_connection.transaction():
-                curs.execute(sql.SQL("UPDATE projectorT SET used_as_default_projector_for_topic_in_meeting_id = %s where id = %s;"), (self.meeting1_id, projector_ids[1]["id"]))
-                curs.execute(sql.SQL("UPDATE projectorT SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_ids[0]["id"],))
+                curs.execute(sql.SQL("UPDATE projector_t SET used_as_default_projector_for_topic_in_meeting_id = %s where id = %s;"), (self.meeting1_id, projector_ids[1]["id"]))
+                curs.execute(sql.SQL("UPDATE projector_t SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_ids[0]["id"],))
             assert projector_ids[1]["id"] == DbUtils.select_id_wrapper(curs, 'meeting', self.meeting1_id, ['default_projector_topic_ids'])['default_projector_topic_ids'][0]
 
     def test_one_to_many_1t_ntR_update_wrong_update_sequence_error(self) -> None:
@@ -95,8 +95,8 @@ class Relations(BaseTestCase):
             projector_ids = curs.execute("SELECT id from projector where used_as_default_projector_for_topic_in_meeting_id = %s", (self.meeting1_id,)).fetchall()
             with pytest.raises(psycopg.errors.RaiseException) as e:
                 with self.db_connection.transaction():
-                    curs.execute(sql.SQL("UPDATE projectorT SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_ids[0]["id"],))
-                    curs.execute(sql.SQL("UPDATE projectorT SET used_as_default_projector_for_topic_in_meeting_id = %s where id = %s;"), (self.meeting1_id, projector_ids[1]["id"]))
+                    curs.execute(sql.SQL("UPDATE projector_t SET used_as_default_projector_for_topic_in_meeting_id = null where id = %s;"), (projector_ids[0]["id"],))
+                    curs.execute(sql.SQL("UPDATE projector_t SET used_as_default_projector_for_topic_in_meeting_id = %s where id = %s;"), (self.meeting1_id, projector_ids[1]["id"]))
         assert 'Exception: NOT NULL CONSTRAINT VIOLATED for meeting.default_projector_topic_ids' in str(e)
 
     def test_one_to_many_1t_ntR_delete_error(self) -> None:
@@ -116,8 +116,8 @@ class Relations(BaseTestCase):
                 field_list = ["meeting_id", "used_as_default_projector_for_agenda_item_list_in_meeting_id", "used_as_default_projector_for_topic_in_meeting_id", "used_as_default_projector_for_list_of_speakers_in_meeting_id", "used_as_default_projector_for_current_los_in_meeting_id", "used_as_default_projector_for_motion_in_meeting_id", "used_as_default_projector_for_amendment_in_meeting_id", "used_as_default_projector_for_motion_block_in_meeting_id", "used_as_default_projector_for_assignment_in_meeting_id", "used_as_default_projector_for_mediafile_in_meeting_id", "used_as_default_projector_for_message_in_meeting_id", "used_as_default_projector_for_countdown_in_meeting_id", "used_as_default_projector_for_assignment_poll_in_meeting_id", "used_as_default_projector_for_motion_poll_in_meeting_id", "used_as_default_projector_for_poll_in_meeting_id"]
                 data = {fname: projector[fname] for fname in field_list}
                 data["sequential_number"] = projector["sequential_number"] + 2
-                new_projector_id = DbUtils.insert_wrapper(curs, "projectorT", data)
-                curs.execute(sql.SQL("UPDATE meetingT SET reference_projector_id = %s where id = %s;"), (new_projector_id, projector["meeting_id"]))
+                new_projector_id = DbUtils.insert_wrapper(curs, "projector_t", data)
+                curs.execute(sql.SQL("UPDATE meeting_t SET reference_projector_id = %s where id = %s;"), (new_projector_id, projector["meeting_id"]))
                 curs.execute(sql.SQL("DELETE FROM projector where id = %s;"), (projector["id"],))
             assert new_projector_id == cast(dict, DbUtils.select_id_wrapper(curs, "meeting", projector["meeting_id"], ["default_projector_topic_ids"]))["default_projector_topic_ids"][0]
 
@@ -132,10 +132,10 @@ class Relations(BaseTestCase):
             with self.db_connection.transaction():
                 pcl_id = 2
                 option_id = 3
-                curs.execute("select setval(pg_get_serial_sequence('poll_candidate_listT', 'id'), %s);", (pcl_id,))
-                assert pcl_id == DbUtils.insert_wrapper(curs, "poll_candidate_listT", {"id": pcl_id, "meeting_id": self.meeting1_id})
-                curs.execute("select setval(pg_get_serial_sequence('optionT', 'id'), %s);", (option_id,))
-                assert option_id == DbUtils.insert_wrapper(curs, "optionT", {"id": option_id, "content_object_id": (content_object_id := f"poll_candidate_list/{pcl_id}"), "meeting_id": self.meeting1_id})
+                curs.execute("select setval(pg_get_serial_sequence('poll_candidate_list_t', 'id'), %s);", (pcl_id,))
+                assert pcl_id == DbUtils.insert_wrapper(curs, "poll_candidate_list_t", {"id": pcl_id, "meeting_id": self.meeting1_id})
+                curs.execute("select setval(pg_get_serial_sequence('option_t', 'id'), %s);", (option_id,))
+                assert option_id == DbUtils.insert_wrapper(curs, "option_t", {"id": option_id, "content_object_id": (content_object_id := f"poll_candidate_list/{pcl_id}"), "meeting_id": self.meeting1_id})
             option_row = DbUtils.select_id_wrapper(curs, "option", option_id, ["id", "content_object_id", "content_object_id_poll_candidate_list_id", "content_object_id_user_id"])
             assert option_row["id"] == option_id
             assert option_row["content_object_id"] == content_object_id
@@ -150,8 +150,8 @@ class Relations(BaseTestCase):
         with self.db_connection.cursor() as curs:
             with self.db_connection.transaction():
                 option_id = 3
-                curs.execute("select setval(pg_get_serial_sequence('poll_candidate_listT', 'id'), %s);", (option_id,))
-                option_id == DbUtils.insert_wrapper(curs, "optionT", {"id": option_id, "content_object_id": (content_object_id := f"user/{self.user1_id}"), "meeting_id": self.meeting1_id})
+                curs.execute("select setval(pg_get_serial_sequence('poll_candidate_list_t', 'id'), %s);", (option_id,))
+                option_id == DbUtils.insert_wrapper(curs, "option_t", {"id": option_id, "content_object_id": (content_object_id := f"user/{self.user1_id}"), "meeting_id": self.meeting1_id})
             option_row = DbUtils.select_id_wrapper(curs, "option", option_id, ["id", "content_object_id", "content_object_id_user_id", "content_object_id_poll_candidate_list_id"])
             assert option_row["id"] == option_id
             assert option_row["content_object_id"] == content_object_id
@@ -167,10 +167,10 @@ class Relations(BaseTestCase):
             with self.db_connection.transaction():
                 mediafile_id = 2
                 los_id = 3
-                curs.execute("select setval(pg_get_serial_sequence('mediafileT', 'id'), %s);", (mediafile_id,))
-                assert mediafile_id == DbUtils.insert_wrapper(curs, "mediafileT", {"id": mediafile_id, "is_public": True, "owner_id": f"meeting/{self.meeting1_id}"})
-                curs.execute("select setval(pg_get_serial_sequence('list_of_speakersT', 'id'), %s);", (los_id,))
-                assert los_id == DbUtils.insert_wrapper(curs, "list_of_speakersT", {"id": los_id, "content_object_id": (content_object_id := f"mediafile/{mediafile_id}"), "meeting_id": self.meeting1_id, "sequential_number": 28})
+                curs.execute("select setval(pg_get_serial_sequence('mediafile_t', 'id'), %s);", (mediafile_id,))
+                assert mediafile_id == DbUtils.insert_wrapper(curs, "mediafile_t", {"id": mediafile_id, "is_public": True, "owner_id": f"meeting/{self.meeting1_id}"})
+                curs.execute("select setval(pg_get_serial_sequence('list_of_speakers_t', 'id'), %s);", (los_id,))
+                assert los_id == DbUtils.insert_wrapper(curs, "list_of_speakers_t", {"id": los_id, "content_object_id": (content_object_id := f"mediafile/{mediafile_id}"), "meeting_id": self.meeting1_id, "sequential_number": 28})
             los_row = DbUtils.select_id_wrapper(curs, "list_of_speakers", los_id, ["id", "content_object_id", "content_object_id_mediafile_id", "content_object_id_topic_id"])
             assert los_row["id"] == los_id
             assert los_row["content_object_id"] == content_object_id
@@ -186,10 +186,10 @@ class Relations(BaseTestCase):
             with self.db_connection.transaction():
                 assignment_id = 2
                 los_id = 3
-                curs.execute("select setval(pg_get_serial_sequence('assignmentT', 'id'), %s);", (assignment_id,))
-                assert assignment_id == DbUtils.insert_wrapper(curs, "assignmentT", {"id": assignment_id, "title": "I am an assignment", "sequential_number": 42, "meeting_id": self.meeting1_id})
-                curs.execute("select setval(pg_get_serial_sequence('list_of_speakersT', 'id'), %s);", (los_id,))
-                assert los_id == DbUtils.insert_wrapper(curs, "list_of_speakersT", {"id": los_id, "content_object_id": (content_object_id := f"assignment/{assignment_id}"), "meeting_id": self.meeting1_id, "sequential_number": 28})
+                curs.execute("select setval(pg_get_serial_sequence('assignment_t', 'id'), %s);", (assignment_id,))
+                assert assignment_id == DbUtils.insert_wrapper(curs, "assignment_t", {"id": assignment_id, "title": "I am an assignment", "sequential_number": 42, "meeting_id": self.meeting1_id})
+                curs.execute("select setval(pg_get_serial_sequence('list_of_speakers_t', 'id'), %s);", (los_id,))
+                assert los_id == DbUtils.insert_wrapper(curs, "list_of_speakers_t", {"id": los_id, "content_object_id": (content_object_id := f"assignment/{assignment_id}"), "meeting_id": self.meeting1_id, "sequential_number": 28})
             los_row = DbUtils.select_id_wrapper(curs, "list_of_speakers", los_id, ["id", "content_object_id", "content_object_id_assignment_id", "content_object_id_topic_id"])
             assert los_row["id"] == los_id
             assert los_row["content_object_id"] == content_object_id
@@ -203,7 +203,7 @@ class Relations(BaseTestCase):
     def test_generic_1GTR_nt(self) -> None:
         with self.db_connection.cursor() as curs:
             with self.db_connection.transaction():
-                DbUtils.insert_many_wrapper(curs, "mediafileT", [
+                DbUtils.insert_many_wrapper(curs, "mediafile_t", [
                     {
                         "is_public": True,
                         "owner_id": f"meeting/{self.meeting1_id}"
@@ -235,7 +235,7 @@ class Relations(BaseTestCase):
         with pytest.raises(psycopg.DatabaseError) as e:
             with self.db_connection.cursor() as curs:
                 with self.db_connection.transaction():
-                    DbUtils.insert_wrapper(curs, "mediafileT", {
+                    DbUtils.insert_wrapper(curs, "mediafile_t", {
                             "is_public": True,
                             "owner_id": f"motion_state/{self.meeting1_id}"
                         })
@@ -245,7 +245,7 @@ class Relations(BaseTestCase):
     def test_generic_nGt_nt(self) -> None:
         with self.db_connection.cursor() as curs:
             with self.db_connection.transaction():
-                tag_ids = DbUtils.insert_many_wrapper(curs, "organization_tagT", [
+                tag_ids = DbUtils.insert_many_wrapper(curs, "organization_tag_t", [
                     {
                         "name": "Orga Tag 1",
                         "color": 0xffee13
@@ -259,13 +259,13 @@ class Relations(BaseTestCase):
                         "color": 0x00ee13
                     },
                 ])
-                DbUtils.insert_many_wrapper(curs, "gm_organization_tag_tagged_idsT", [
+                DbUtils.insert_many_wrapper(curs, "gm_organization_tag_tagged_ids_t", [
                     {"organization_tag_id": tag_ids[0], "tagged_id": f"committee/{self.committee1_id}"},
                     {"organization_tag_id": tag_ids[0], "tagged_id": f"meeting/{self.meeting1_id}"},
                     {"organization_tag_id": tag_ids[1], "tagged_id": f"committee/{self.committee1_id}"},
                     {"organization_tag_id": tag_ids[2], "tagged_id": f"meeting/{self.meeting1_id}"},
                 ])
-            rows = DbUtils.select_id_wrapper(curs, "gm_organization_tag_tagged_idsT", field_names=["id", "organization_tag_id", "tagged_id", "tagged_id_committee_id", "tagged_id_meeting_id"])
+            rows = DbUtils.select_id_wrapper(curs, "gm_organization_tag_tagged_ids_t", field_names=["id", "organization_tag_id", "tagged_id", "tagged_id_committee_id", "tagged_id_meeting_id"])
             expected_results = ((1, 1, "committee/1", 1, None), (2, 1, "meeting/1", None, 1), (3, 2, "committee/1", 1, None), (4, 3, "meeting/1", None, 1))
             for i, row in enumerate (rows):
                 assert tuple(row.values()) == expected_results[i]
@@ -279,8 +279,8 @@ class Relations(BaseTestCase):
         with pytest.raises(psycopg.DatabaseError) as e:
             with self.db_connection.cursor() as curs:
                 with self.db_connection.transaction():
-                    tag_id = DbUtils.insert_wrapper(curs, "organization_tagT", {"name": "Orga Tag 1", "color": 0xffee13})
-                    DbUtils.insert_many_wrapper(curs, "gm_organization_tag_tagged_idsT", [
+                    tag_id = DbUtils.insert_wrapper(curs, "organization_tag_t", {"name": "Orga Tag 1", "color": 0xffee13})
+                    DbUtils.insert_many_wrapper(curs, "gm_organization_tag_tagged_ids_t", [
                         {"organization_tag_id": tag_id, "tagged_id": f"committee/{self.committee1_id}"},
                         {"organization_tag_id": tag_id, "tagged_id": f"motion_state/{self.meeting1_id}"},
                     ])
@@ -289,9 +289,9 @@ class Relations(BaseTestCase):
     def test_generic_nGt_unique_constraint_error(self) -> None:
         with self.db_connection.cursor() as curs:
             with self.db_connection.transaction():
-                tag_id = DbUtils.insert_wrapper(curs, "organization_tagT", {"name": "Orga Tag 1", "color": 0xffee13})
-                DbUtils.insert_wrapper(curs, "gm_organization_tag_tagged_idsT", {"organization_tag_id": tag_id, "tagged_id": f"committee/{self.committee1_id}"})
+                tag_id = DbUtils.insert_wrapper(curs, "organization_tag_t", {"name": "Orga Tag 1", "color": 0xffee13})
+                DbUtils.insert_wrapper(curs, "gm_organization_tag_tagged_ids_t", {"organization_tag_id": tag_id, "tagged_id": f"committee/{self.committee1_id}"})
             with pytest.raises(psycopg.DatabaseError) as e:
                 with self.db_connection.transaction():
-                    DbUtils.insert_wrapper(curs, "gm_organization_tag_tagged_idsT", {"organization_tag_id": tag_id, "tagged_id": f"committee/{self.committee1_id}"})
+                    DbUtils.insert_wrapper(curs, "gm_organization_tag_tagged_ids_t", {"organization_tag_id": tag_id, "tagged_id": f"committee/{self.committee1_id}"})
             assert 'duplicate key value violates unique constraint' in str(e)

--- a/models.yml
+++ b/models.yml
@@ -43,6 +43,9 @@
 #         reference:
 #           - agenda_item
 #           - assignment
+#       The `sql`-attribute can only be used for relation-types in combination with a `to`-attribute. The `required` attribute
+#       is not allowed, because in hand written sql we can't check for.
+#       Currently implemented only for n:m-relations without generating an intermediate table.
 #       List of allowed and implemented relations
 #           Symbols:
 #               1 = relation
@@ -73,6 +76,7 @@
 #           ("nt", "nGt"): (FieldSqlErrorType.SQL, False),
 #           ("nt", "nt"): (FieldSqlErrorType.SQL, "primary_decide_alphabetical"),
 #           ("ntR", "1r"): (FieldSqlErrorType.SQL, False),
+#           ("nts", "nts"): (FieldSqlErrorType.SQL, False),
 #
 #     - on_delete: This fields determines what should happen with the foreign model if
 #       this model gets deleted. Possible values are:
@@ -84,9 +88,6 @@
 #     - You can add JSON Schema properties to the fields like `enum`, `description`,
 #       `items`, `maxLength` and `minimum`
 # Additional properties:
-#     - The optional property `sql` may contain an SQL statement which is used to calculate the value of this field. This
-#       field does not exist with its own value in a table, but is always defined in a view. It can be used on all
-#        field types, not only relations.
 #     - The property `read_only` describes a field that can not be changed by an action.
 #     - The property `default` describes the default value that is used for new objects.
 #     - The property `required` describes that this field can not be null or an empty
@@ -197,7 +198,6 @@ organization:
     type: relation-list
     to: committee/organization_id
     restriction_mode: B
-    sql: (select array_agg(c.id) from committeeT c) as committee_ids
     reference: committee
   active_meeting_ids:
     type: relation-list
@@ -357,20 +357,20 @@ user:
   # - is member (= has group-rights) of a meeting in the committee
   # TODO: fix sql, not correct for the current design and naming
   committee_ids:
-    type: number[]
+    type: relation-list
     to: committee/user_ids
     restriction_mode: E
     read_only: true
     description: "Calculated field: Returns committee_ids, where the user is manager or member in a meeting"
-    sql: >-
-      select array_agg(committee_id) from (
+    sqlTODO: >-
+      (select array_agg(committee_id) from
           select m.committee_id as committee_id from group_to_user gtu
             join groupT g on g.id = gtu.group_id
             join meetingT m on m.id = g.meeting_id
             where gtu.user_id = u.id
           union
           select ctu.committee_id as committee_id from committee_manager_to_user ctu where ctu.user_id = u.id
-        ) as cs
+        ) as committee_ids
 
   # committee specific permissions
   committee_management_ids:
@@ -414,6 +414,7 @@ user:
     type: number[]
     description: Calculated. All ids from meetings calculated via meeting_user and group_ids as integers.
     read_only: true
+    sql: todo
     restriction_mode: E
   organization_id:
     type: relation
@@ -741,20 +742,20 @@ committee:
     reference: meeting
     restriction_mode: A
   user_ids:
-    type: number[]
+    type: relation-list
     to: user/committee_ids
     restriction_mode: A
     read_only: true
     description: "Calculated field: All users which are in a group of a meeting, belonging to the committee or beeing manager of the committee"
-    sql: >-
-      select array_agg(user_id) from (
+    sqlTODO: >-
+      (select array_agg(user_id) from
         select gtu.user_id as user_id from meetingT m
           join groupT g on g.meeting_id = m.id
           join group_to_user gtu on gtu.group_id = g.id
           where m.committee_id = c.id
         union
         select ctu.user_id as user_id from committee_manager_to_user ctu where ctu.committee_id = c.id
-      ) as x
+      ) as user_ids
   manager_ids:
     type: relation-list
     to: user/committee_management_ids


### PR DESCRIPTION
- attribute sql only used for relation fields
- error/warning reporting on stdout and inside schema file
- fixed table names (now with "_t"-appendix)