### PR TITLE
Add orga setting for duplicate-from mandatory

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -142,6 +142,9 @@ organization:
     restriction_mode: A
     enum: *languages
     required: true
+  enable_duplicate_from_mandatory:
+    type: boolean
+    restriction_mode: A
 
   # Saml settings
   saml_enabled:

--- a/models.yml
+++ b/models.yml
@@ -142,7 +142,7 @@ organization:
     restriction_mode: A
     enum: *languages
     required: true
-  enable_duplicate_from_mandatory:
+  require_duplicate_from:
     type: boolean
     restriction_mode: A
 


### PR DESCRIPTION
closes https://github.com/OpenSlides/openslides-meta/issues/125

If this setting is set, committee admins must choose a template as duplicated-from at meeting create.