### PR TITLE
Change restriction mode of `active_meeting_ids` to `A`

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -179,7 +179,7 @@ organization:
     to: committee/organization_id
   active_meeting_ids:
     type: relation-list
-    restriction_mode: B
+    restriction_mode: A
     to: meeting/is_active_in_organization_id
   archived_meeting_ids:
     type: relation-list


### PR DESCRIPTION
Needed for https://github.com/OpenSlides/openslides-client/pull/3965

It is already possible to get this value by iterating over meeting ids so it should not be a big deal to just make this property public.