### PR TITLE
remove required-attr from chat_message/meeting_user_id

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -4191,7 +4191,6 @@ chat_message:
     type: relation
     to: meeting_user/chat_message_ids
     restriction_mode: A
-    required: true
     constant: true
   chat_group_id:
     type: relation


### PR DESCRIPTION
On deleting meeting_user the meeting_user_id should be set to NULL in the chat_message to keep the message
See https://github.com/OpenSlides/openslides-backend/issues/2566