### PR TITLE
Remove function truncate_tables from relational schema generation

### DIFF
--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -42,19 +42,6 @@ begin
     RETURN NULL;  -- AFTER TRIGGER needs no return
 end;
 $not_null_trigger$ language plpgsql;
-
-CREATE FUNCTION truncate_tables(username IN VARCHAR) RETURNS void AS $$
-DECLARE
-    statements CURSOR FOR
-        SELECT tablename FROM pg_tables
-        WHERE tableowner = username AND schemaname = 'public';
-BEGIN
-    FOR stmt IN statements LOOP
-        EXECUTE 'TRUNCATE TABLE ' || quote_ident(stmt.tablename) || ' RESTART IDENTITY CASCADE;';
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
 -- MODELS_YML_CHECKSUM = 'e3bcb2c45850469b5e56d3542d12ea15'
 -- Type definitions
 

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -616,19 +616,6 @@ class Helper:
             RETURN NULL;  -- AFTER TRIGGER needs no return
         end;
         $not_null_trigger$ language plpgsql;
-
-        CREATE FUNCTION truncate_tables(username IN VARCHAR) RETURNS void AS $$
-        DECLARE
-            statements CURSOR FOR
-                SELECT tablename FROM pg_tables
-                WHERE tableowner = username AND schemaname = 'public';
-        BEGIN
-            FOR stmt IN statements LOOP
-                EXECUTE 'TRUNCATE TABLE ' || quote_ident(stmt.tablename) || ' RESTART IDENTITY CASCADE;';
-            END LOOP;
-        END;
-        $$ LANGUAGE plpgsql;
-
         """
     )
     FIELD_TEMPLATE = string.Template(


### PR DESCRIPTION
function will be called dynamically from backend at test session start. Concerning schemata or even different databases it is easier to maintain in future from backend.

Belongs to https://github.com/OpenSlides/openslides-backend/issues/2582