### PR TITLE
Add motions_allow_additional_submitter_text_in_create setting to meeting

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -1168,6 +1168,9 @@ meeting:
     type: boolean
     default: True
     restriction_mode: B
+  motions_allow_additional_submitter_text_in_create:
+    type: boolean
+    restriction_mode: B
   motions_recommendations_by:
     type: string
     restriction_mode: B

--- a/models.yml
+++ b/models.yml
@@ -1168,7 +1168,7 @@ meeting:
     type: boolean
     default: True
     restriction_mode: B
-  motions_allow_additional_submitter_text_in_create:
+  motions_create_enable_additional_submitter_text:
     type: boolean
     restriction_mode: B
   motions_recommendations_by:


### PR DESCRIPTION
Necessary for OpenSlides/openslides-backend#2753 and OpenSlides/openslides-client#4405