### PR TITLE
No longer set milestone for 'update-meta' PRs

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -67,4 +67,3 @@ jobs:
           reviewers: ${{ inputs.assignee }}
           assignees: ${{ inputs.assignee }}
           labels: dependencies
-          milestone: 4


### PR DESCRIPTION
This was a hardcoded id until now and was error prone since the beginning. It resulted in non-sensible milestones being set (due to inconsistent IDs accross repos).
Most recently it caused abortion of the actions as openslides-meta started using meta as submod but having no milestones defined.