### PR TITLE
[Rel-DB] Fix and unify the sql attributes

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -399,7 +399,7 @@ user:
     restriction_mode: E
     read_only: true
     description: "Calculated field: Returns committee_ids, where the user is manager or member in a meeting"
-    sql:
+    sql: |
       (
         SELECT array_agg(DISTINCT committee_id ORDER BY committee_id)
         FROM (
@@ -420,7 +420,7 @@ user:
           FROM nm_committee_manager_ids_user cmu
           WHERE cmu.user_id = u.id
 
-          UNION 
+          UNION
 
           -- Select home_committee_id from user
 
@@ -470,12 +470,12 @@ user:
     type: relation-list
     description: Calculated. All ids from meetings calculated via meeting_user and group_ids as integers.
     read_only: true
-    sql: 
+    sql: |
       (
-        SELECT array_agg(DISTINCT mu.meeting_id ORDER BY mu.meeting_id) 
-        FROM meeting_user_t mu 
-        INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id 
-        WHERE mu.user_id = u.id
+      SELECT array_agg(DISTINCT mu.meeting_id ORDER BY mu.meeting_id)
+      FROM meeting_user_t mu
+      INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id
+      WHERE mu.user_id = u.id
       ) AS meeting_ids
     to: meeting/user_ids
     restriction_mode: E
@@ -820,34 +820,34 @@ committee:
     restriction_mode: A
     read_only: true
     description: "Calculated field: All users which are in a group of a meeting, belonging to the committee or beeing manager of the committee"
-    sql: 
-      "(
-        SELECT array_agg(DISTINCT user_id ORDER BY user_id)
-        FROM (
+    sql: |
+      (
+      SELECT array_agg(DISTINCT user_id ORDER BY user_id)
+      FROM (
 
-          -- Select user_ids from committees meetings
+      -- Select user_ids from committees meetings
 
-          SELECT mu.user_id
-          FROM meeting_t AS m
-          INNER JOIN meeting_user_t AS mu ON mu.meeting_id = m.id
-          INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id
-          WHERE m.committee_id = c.id
-          
-          UNION
+      SELECT mu.user_id
+      FROM meeting_t AS m
+      INNER JOIN meeting_user_t AS mu ON mu.meeting_id = m.id
+      INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id
+      WHERE m.committee_id = c.id
 
-          -- Select user_ids from committee managers
+      UNION
 
-          SELECT cmu.user_id
-          FROM nm_committee_manager_ids_user cmu
-          WHERE cmu.committee_id = c.id
-          
-          UNION 
+      -- Select user_ids from committee managers
 
-          -- Select user_id from home committees
+      SELECT cmu.user_id
+      FROM nm_committee_manager_ids_user cmu
+      WHERE cmu.committee_id = c.id
 
-          SELECT u.id FROM user_t u WHERE u.home_committee_id = c.id
-        ) _
-      ) AS user_ids"
+      UNION
+
+      -- Select user_id from home committees
+
+      SELECT u.id FROM user_t u WHERE u.home_committee_id = c.id
+      ) _
+      ) AS user_ids
   manager_ids:
     type: relation-list
     to: user/committee_management_ids
@@ -1938,12 +1938,12 @@ meeting:
     type: relation-list
     description: Calculated. All user ids from all users assigned to groups of this meeting.
     read_only: true
-    sql: 
+    sql: |
       (
-        SELECT array_agg(DISTINCT mu.user_id ORDER BY mu.user_id) 
-        FROM meeting_user_t mu 
-        INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id 
-        WHERE mu.meeting_id = m.id
+      SELECT array_agg(DISTINCT mu.user_id ORDER BY mu.user_id)
+      FROM meeting_user_t mu
+      INNER JOIN nm_group_meeting_user_ids_meeting_user AS gmu ON mu.id = gmu.meeting_user_id
+      WHERE mu.meeting_id = m.id
       ) AS user_ids
     to: user/meeting_ids
     restriction_mode: A
@@ -4227,11 +4227,11 @@ projector:
     required: true
     constant: true
 
-# A projection is an M2M model between a projector and an element which is assigned to it. 
-# It can either be the current projection, a preview or a history projection (i.e. previously 
-# projected, with reference retained for protocolling purposes). The projection can only be 
-# connected to the projector once in one of these contexts. Projections are projector- and 
-# element-specific, meaning that, while the type of projector reference may change, neither 
+# A projection is an M2M model between a projector and an element which is assigned to it.
+# It can either be the current projection, a preview or a history projection (i.e. previously
+# projected, with reference retained for protocolling purposes). The projection can only be
+# connected to the projector once in one of these contexts. Projections are projector- and
+# element-specific, meaning that, while the type of projector reference may change, neither
 # the referenced projector, nor the content_object of the projection may be changed.
 projection:
   id: *id_field


### PR DESCRIPTION
YAML has many different ways to represent multi line strings. The current version uses different onces. This PR unifies them.

[Here](https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines) is a description, what is possible with yaml.

The current version also has a yaml-syntax-error, so it could not be pared by `openslides-go`