### PR TITLE
Permission poll progress

### DIFF
--- a/permission.yml
+++ b/permission.yml
@@ -10,12 +10,17 @@ agenda_item:
   can_manage:
     can_see_internal:
       can_see:
+  can_manage_polls:
+    can_see_progress:
+      can_see_internal:
+        can_see:
 assignment:
   can_manage:
     can_nominate_other:
       can_see:
   can_manage_polls:
-    can_see:
+    can_see_progress:
+      can_see:
   can_nominate_self:
     can_see:
 chat:
@@ -49,14 +54,12 @@ motion:
     can_forward:
       can_see:
   can_manage_polls:
-    can_see:
+    can_see_progress:
+      can_see:
   can_support:
     can_see:
   can_see_origin:
     can_see:
-poll:
-  can_manage:
-    can_see_progress:
 projector:
   can_manage:
     can_see:

--- a/permission.yml
+++ b/permission.yml
@@ -7,67 +7,67 @@
 # implicitly agenda_item.can_see_internal and agenda_item.can_see.
 
 agenda_item:
-    can_manage:
-        can_see_internal:
-            can_see:
+  can_manage:
+    can_see_internal:
+      can_see:
 assignment:
-    can_manage:
-        can_nominate_other:
-            can_see:
-    can_manage_polls:
-        can_see:
-    can_nominate_self:
-        can_see:
+  can_manage:
+    can_nominate_other:
+      can_see:
+  can_manage_polls:
+    can_see:
+  can_nominate_self:
+    can_see:
 chat:
-    can_manage:
+  can_manage:
 list_of_speakers:
-    can_manage:
-        can_see:
-    can_be_speaker:
-    can_manage_moderator_notes:
-        can_see_moderator_notes:
+  can_manage:
+    can_see:
+  can_be_speaker:
+  can_manage_moderator_notes:
+    can_see_moderator_notes:
 mediafile:
-    can_manage:
-        can_see:
+  can_manage:
+    can_see:
 meeting:
-    can_manage_settings:
-    can_manage_logos_and_fonts:
-    can_see_frontpage:
-    can_see_autopilot:
-    can_see_livestream:
-    can_see_history:
+  can_manage_settings:
+  can_manage_logos_and_fonts:
+  can_see_frontpage:
+  can_see_autopilot:
+  can_see_livestream:
+  can_see_history:
 motion:
-    can_manage:
-        can_manage_metadata:
-            can_see:
-        can_see_internal:
-            can_see:
-        can_create:
-            can_see:
-        can_create_amendments:
-            can_see:
-        can_forward:
-            can_see:
-    can_manage_polls:
-        can_see:
-    can_support:
-        can_see:
-    can_see_origin:
-        can_see:
+  can_manage:
+    can_manage_metadata:
+      can_see:
+    can_see_internal:
+      can_see:
+    can_create:
+      can_see:
+    can_create_amendments:
+      can_see:
+    can_forward:
+      can_see:
+  can_manage_polls:
+    can_see:
+  can_support:
+    can_see:
+  can_see_origin:
+    can_see:
 poll:
-    can_manage:
-        can_see_progress:
+  can_manage:
+    can_see_progress:
 projector:
-    can_manage:
-        can_see:
+  can_manage:
+    can_see:
 tag:
-    can_manage:
+  can_manage:
 user:
-    can_manage:
-        can_manage_presence:
-            can_see:
-        can_update:
-            can_see_sensitive_data:
-                can_see:
-    can_edit_own_delegation:
+  can_manage:
+    can_manage_presence:
+      can_see:
+    can_update:
+      can_see_sensitive_data:
         can_see:
+  can_edit_own_delegation:
+    can_see:

--- a/permission.yml
+++ b/permission.yml
@@ -10,16 +10,16 @@ agenda_item:
   can_manage:
     can_see_internal:
       can_see:
-  can_manage_polls:
-    can_see_progress:
+  can_manage_polls: # Can create, start and stop topic polls
+    can_see_poll: # Can see unpublished poll results for topics
       can_see_internal:
         can_see:
 assignment:
   can_manage:
     can_nominate_other:
       can_see:
-  can_manage_polls:
-    can_see_progress:
+  can_manage_polls: # Can create, start and stop assignment polls
+    can_see_polls:  # Can see unpublished poll results for assignments
       can_see:
   can_nominate_self:
     can_see:
@@ -53,13 +53,15 @@ motion:
       can_see:
     can_forward:
       can_see:
-  can_manage_polls:
-    can_see_progress:
+  can_manage_polls: # Can create, start and stop motion polls
+    can_see_polls: # Can see unpublished poll results for motions
       can_see:
   can_support:
     can_see:
   can_see_origin:
     can_see:
+poll:
+  can_see_progress: # Can see all progressbars (Topic, Assignemnt, Motion)
 projector:
   can_manage:
     can_see:


### PR DESCRIPTION
This is a proposal for a refactor of the poll permissions.

For a better diff, see: https://github.com/OpenSlides/openslides-meta/commit/b1caa741f6f3f7c9a2d5991633b59fa23b323fce

The old system used the permission poll.can_manage only for topic-polls. This proposal renames this to `agenda_item.can_manage_polls` what is more clear.

The old system used poll.can_see_progress for topic, motion and assignment polls. This means, that it was not possible to give a user only the permission for one of the collections. If we make a distinction for `can_manage_pools` we should also make a distinction for `can_see_progress`.

The old system has to problem, that if a user has the permission to create topic polls (poll.can_manage), he also gets the permission to see the progress bar for motion or assignment polls. This was probably not intended.

If you want, we can keep the old system for now, and I only change the permissions on the new-vote-service-branch 