### PR TITLE
Remove projection/content

### DIFF
--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -1,7 +1,7 @@
 
 -- schema_relational.sql for initial database setup OpenSlides
 -- Code generated. DO NOT EDIT.
--- MODELS_YML_CHECKSUM = '45a8410dde8705474ea7e4c08430f1df'
+-- MODELS_YML_CHECKSUM = '4e5fb835b03145d8d69dee709d1b4aa7'
 
 
 -- Database parameters
@@ -1128,7 +1128,6 @@ CREATE TABLE projection_t (
     stable boolean DEFAULT False,
     weight integer,
     type varchar(256),
-    content jsonb,
     current_projector_id integer,
     preview_projector_id integer,
     history_projector_id integer,

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -101,7 +101,6 @@ class GenerateCodeBlocks:
             "type",
             "restriction_mode",
             "minimum",
-            "calculated",
             "description",
             "read_only",
             "enum",
@@ -215,11 +214,6 @@ class GenerateCodeBlocks:
         - string or a callable with return value of type SchemaZoneTexts
         - type as string
         """
-        if fdata.get("calculated"):
-            return (
-                f"type:{fdata.get('type')} is marked as a calculated field and not generated in schema\n",
-                "",
-            )
         if fname == "id":
             type_ = "primary_key"
         elif (

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -49,7 +49,6 @@ VALID_TYPES = DATA_TYPES + RELATION_TYPES
 
 OPTIONAL_ATTRIBUTES = (
     "description",
-    "calculated",
     "required",
     "read_only",
     "constant",
@@ -154,9 +153,6 @@ class Checker:
                     f"Required attribute '{attr}' for collectionfield {collectionfield} is missing."
                 )
                 return
-
-        if field.get("calculated"):
-            return
 
         valid_attributes = list(OPTIONAL_ATTRIBUTES) + required_attributes
         if type == "string[]":

--- a/models.yml
+++ b/models.yml
@@ -4106,12 +4106,6 @@ projection:
   type:
     type: string
     restriction_mode: A
-
-  content:
-    type: JSON
-    # calculated: true
-    restriction_mode: A
-
   current_projector_id:
     type: relation
     reference: projector


### PR DESCRIPTION
This is a cleanup for the time, when the projector-service is released and the field projection/content is not be calculated by the autoupdate anymore.

With the new vote service, there is no other field, that is calculated by the autoupdate service. So the functionality can be removed. This also fixes the ambiguous of the term "calculated".

This PR should only be merged, when we are sure, that the projector service is release before or together with rel-db.

If the projector service is released before rel-db, then there is no need to backport this PR on main, since it is only a cleanup PR. There is no harm, that `projector/content` exists together with the new projector-service