### PR TITLE
Add orga setting for disable forward with attachments

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -118,6 +118,9 @@ organization:
     type: relation-list
     to: gender/organization_id
     restriction_mode: A
+  disable_forward_with_attachments:
+    type: boolean
+    restriction_mode: A
 
   # Configuration (only for the server owner)
   enable_electronic_voting:


### PR DESCRIPTION
Adds the organization setting:

disable_forward_with_attachments:
    type: boolean
    restriction_mode: A

Needed for:
https://github.com/OpenSlides/openslides-backend/issues/3189

