### PR TITLE
Add log triggers for calculated fields

### DIFF
--- a/collections/committee.yml
+++ b/collections/committee.yml
@@ -52,9 +52,33 @@ fields:
           UNION
 
           -- Select user_id from home committees
-          SELECT u.id FROM user_t u WHERE u.home_committee_id = c.id
+          SELECT u.id FROM user_t u
+          WHERE u.home_committee_id = c.id
         ) _
       ) AS user_ids
+    log_triggers_data:
+      - define_trigger_on:
+          table: meeting_user_t
+        relational_column: meeting_id
+        log_collection_id:
+          sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
+        log_value:
+          column: user_id
+      - define_trigger_on:
+          table: nm_committee_manager_ids_user_t
+        relational_column: committee_id
+        log_collection_id:
+          column: committee_id
+        log_value:
+          column: user_id
+      - define_trigger_on:
+          table: user_t
+          update_columns: home_committee_id
+        relational_column: home_committee_id
+        log_value:
+          column: id
+        log_collection_id:
+          column: home_committee_id
   manager_ids:
     type: relation-list
     to: user/committee_management_ids

--- a/collections/committee.yml
+++ b/collections/committee.yml
@@ -57,29 +57,20 @@ fields:
           WHERE u.home_committee_id = c.id
         ) _
       ) AS user_ids
-    log_triggers_data:
-      - define_trigger_on:
-          table: meeting_user_t
+    log_triggers:
+      - on_table: meeting_user_t
         relational_column: meeting_id
-        log_collection_id:
-          sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
-        log_value:
-          column: user_id
-      - define_trigger_on:
-          table: nm_committee_manager_ids_user_t
+        log_collection_id_sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
+        log_value_column: user_id
+      - on_table: nm_committee_manager_ids_user_t
         relational_column: committee_id
-        log_collection_id:
-          column: committee_id
-        log_value:
-          column: user_id
-      - define_trigger_on:
-          table: user_t
-          update_columns: home_committee_id
+        log_collection_id_column: committee_id
+        log_value_column: user_id
+      - on_table: user_t
+        on_columns: home_committee_id
         relational_column: home_committee_id
-        log_value:
-          column: id
-        log_collection_id:
-          column: home_committee_id
+        log_collection_id_column: home_committee_id
+        log_value_column: id
   manager_ids:
     type: relation-list
     to: user/committee_management_ids

--- a/collections/committee.yml
+++ b/collections/committee.yml
@@ -59,16 +59,13 @@ fields:
       ) AS user_ids
     log_triggers:
       - on_table: meeting_user_t
-        relational_column: meeting_id
         log_collection_id_sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
         log_value_column: user_id
       - on_table: nm_committee_manager_ids_user_t
-        relational_column: committee_id
         log_collection_id_column: committee_id
         log_value_column: user_id
       - on_table: user_t
         on_columns: home_committee_id
-        relational_column: home_committee_id
         log_collection_id_column: home_committee_id
         log_value_column: id
   manager_ids:

--- a/collections/committee.yml
+++ b/collections/committee.yml
@@ -52,7 +52,8 @@ fields:
           UNION
 
           -- Select user_id from home committees
-          SELECT u.id FROM user_t u
+          SELECT u.id
+          FROM user_t u
           WHERE u.home_committee_id = c.id
         ) _
       ) AS user_ids

--- a/collections/meeting.yml
+++ b/collections/meeting.yml
@@ -1077,6 +1077,14 @@ fields:
       ) AS user_ids
     to: user/meeting_ids
     restriction_mode: A
+    log_triggers_data:
+      - define_trigger_on:
+          table: meeting_user_t
+        relational_column: meeting_id
+        log_collection_id:
+          column: meeting_id
+        log_value:
+          column: user_id
   reference_projector_id:
     type: relation
     reference: projector

--- a/collections/meeting.yml
+++ b/collections/meeting.yml
@@ -1077,14 +1077,11 @@ fields:
       ) AS user_ids
     to: user/meeting_ids
     restriction_mode: A
-    log_triggers_data:
-      - define_trigger_on:
-          table: meeting_user_t
+    log_triggers:
+      - on_table: meeting_user_t
         relational_column: meeting_id
-        log_collection_id:
-          column: meeting_id
-        log_value:
-          column: user_id
+        log_collection_id_column: meeting_id
+        log_value_column: user_id
   reference_projector_id:
     type: relation
     reference: projector

--- a/collections/meeting.yml
+++ b/collections/meeting.yml
@@ -1079,7 +1079,6 @@ fields:
     restriction_mode: A
     log_triggers:
       - on_table: meeting_user_t
-        relational_column: meeting_id
         log_collection_id_column: meeting_id
         log_value_column: user_id
   reference_projector_id:

--- a/collections/user.yml
+++ b/collections/user.yml
@@ -127,6 +127,30 @@ fields:
           WHERE u_hc.home_committee_id IS NOT NULL AND u_hc.id = u.id
         ) AS ci
       ) AS committee_ids
+    log_triggers_data:
+      - define_trigger_on:
+          table: meeting_user_t
+        relational_column: meeting_id
+        log_collection_id:
+          column: user_id
+        log_value:
+          column:
+          sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
+      - define_trigger_on:
+          table: nm_committee_manager_ids_user_t
+        relational_column: committee_id
+        log_collection_id:
+          column: user_id
+        log_value:
+          column: committee_id
+      - define_trigger_on:
+          table: user_t
+          update_columns: home_committee_id
+        relational_column: home_committee_id
+        log_value:
+          column: home_committee_id
+        log_collection_id:
+          column: id
   # committee specific permissions
   committee_management_ids:
     type: relation-list
@@ -189,6 +213,14 @@ fields:
       ) AS meeting_ids
     to: meeting/user_ids
     restriction_mode: E
+    log_triggers_data:
+      - define_trigger_on:
+          table: meeting_user_t
+        relational_column: user_id
+        log_collection_id:
+          column: user_id
+        log_value:
+          column: meeting_id
   organization_id:
     type: relation
     reference: organization

--- a/collections/user.yml
+++ b/collections/user.yml
@@ -129,16 +129,13 @@ fields:
       ) AS committee_ids
     log_triggers:
       - on_table: meeting_user_t
-        relational_column: meeting_id
         log_collection_id_column: user_id
         log_value_sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
       - on_table: nm_committee_manager_ids_user_t
-        relational_column: committee_id
         log_collection_id_column: user_id
         log_value_column: committee_id
       - on_table: user_t
         on_columns: home_committee_id
-        relational_column: home_committee_id
         log_collection_id_column: id
         log_value_column: home_committee_id
   # committee specific permissions
@@ -205,7 +202,6 @@ fields:
     restriction_mode: E
     log_triggers:
       - on_table: meeting_user_t
-        relational_column: user_id
         log_collection_id_column: user_id
         log_value_column: meeting_id
   organization_id:

--- a/collections/user.yml
+++ b/collections/user.yml
@@ -127,30 +127,20 @@ fields:
           WHERE u_hc.home_committee_id IS NOT NULL AND u_hc.id = u.id
         ) AS ci
       ) AS committee_ids
-    log_triggers_data:
-      - define_trigger_on:
-          table: meeting_user_t
+    log_triggers:
+      - on_table: meeting_user_t
         relational_column: meeting_id
-        log_collection_id:
-          column: user_id
-        log_value:
-          column:
-          sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
-      - define_trigger_on:
-          table: nm_committee_manager_ids_user_t
+        log_collection_id_column: user_id
+        log_value_sql: SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id
+      - on_table: nm_committee_manager_ids_user_t
         relational_column: committee_id
-        log_collection_id:
-          column: user_id
-        log_value:
-          column: committee_id
-      - define_trigger_on:
-          table: user_t
-          update_columns: home_committee_id
+        log_collection_id_column: user_id
+        log_value_column: committee_id
+      - on_table: user_t
+        on_columns: home_committee_id
         relational_column: home_committee_id
-        log_value:
-          column: home_committee_id
-        log_collection_id:
-          column: id
+        log_collection_id_column: id
+        log_value_column: home_committee_id
   # committee specific permissions
   committee_management_ids:
     type: relation-list
@@ -213,14 +203,11 @@ fields:
       ) AS meeting_ids
     to: meeting/user_ids
     restriction_mode: E
-    log_triggers_data:
-      - define_trigger_on:
-          table: meeting_user_t
+    log_triggers:
+      - on_table: meeting_user_t
         relational_column: user_id
-        log_collection_id:
-          column: user_id
-        log_value:
-          column: meeting_id
+        log_collection_id_column: user_id
+        log_value_column: meeting_id
   organization_id:
     type: relation
     reference: organization

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -269,6 +269,125 @@ BEGIN
 END;
 $log_modified_related_trigger$ LANGUAGE plpgsql;
 
+-- If insert:
+    -- If field is null -> skip
+    -- Else:
+        -- In before trigger (New value is not null) -> log if not present in OLD.calculated field
+-- If update:
+    -- If old and new are same -> skip (checked by the definition `update of column_name`)
+    -- Else:
+        -- In before trigger: If New value is not null -> log if not present in OLD.calculated field
+        -- In after trigger: If New value is null (Old value is not null) -> log if not present in NEW.calculated field
+-- If delete:
+    -- If Old value is null -> skip
+    -- Else:
+        -- In after trigger (Old value is not null) -> log if not present in NEW.calculated field
+
+
+-- Not just arrays, but ids_arrays.. Make the name more short and precise
+CREATE OR REPLACE FUNCTION iu_log_modified_calculated_array_field()
+RETURNS trigger AS $log_modified_calculated_array_field_trigger$
+DECLARE
+    foreign_table TEXT := TG_ARGV[0];  -- Collection for which the log entry should be written
+    foreign_id_sql TEXT := TG_ARGV[1];  -- Custom SQL to get id for `foreign_table`
+    fk_field TEXT := TG_ARGV[2];  -- Field for which the log entry should be written
+    own_column TEXT := TG_ARGV[3];  -- Change of value in this must fire log trigger
+    column_with_log_data TEXT := TG_ARGV[4];  -- Value that will be added (or not) to the calculated field
+    log_data_sql TEXT := TG_ARGV[5];  -- Custom SQL to get value for the calculated field
+    foreign_id INTEGER;  -- Id of `foreign_table` for which the log entry should be written
+    fqid_var TEXT;  -- Parameter 1 to log function
+    old_fk_field_value INTEGER[]; -- Old value of the calculated field
+    log_value INTEGER;  -- Must become the part of calculated field after the transaction
+    new_own_value INTEGER;
+BEGIN
+    -- No need to process new instance without field
+    -- Value deletion on update is processed in after-trigger
+    new_own_value := hstore(NEW) -> own_column;
+    IF new_own_value IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF (foreign_id_sql != '') THEN
+        EXECUTE format(foreign_id_sql) INTO foreign_id USING NEW;
+        IF foreign_id IS NULL THEN
+            RETURN NEW;
+        END IF;
+    ELSE
+        foreign_id := hstore(NEW) -> own_column;
+    END IF;
+
+    IF (column_with_log_data != '') THEN
+        log_value := hstore(NEW) -> column_with_log_data;
+    ELSE
+        EXECUTE format(foreign_id_sql) INTO log_value USING NEW;
+    END IF;
+
+    IF log_value IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    EXECUTE format('SELECT %I from "%I" where id = %L', fk_field, foreign_table, foreign_id) INTO old_fk_field_value;
+    IF old_fk_field_value IS NULL OR NOT (log_value = ANY(old_fk_field_value)) THEN
+        fqid_var := foreign_table || '/' || foreign_id;
+        CALL log_field_change('update', fqid_var, ARRAY[fk_field]);
+    END IF;
+
+    RETURN NEW;
+END;
+$log_modified_calculated_array_field_trigger$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ud_log_modified_calculated_array_field()
+RETURNS trigger AS $log_modified_calculated_array_field_trigger$
+DECLARE
+    foreign_table TEXT := TG_ARGV[0];
+    foreign_id_sql TEXT := TG_ARGV[1];
+    fk_field TEXT := TG_ARGV[2];
+    own_column TEXT := TG_ARGV[3];
+    column_with_log_data TEXT := TG_ARGV[4];
+    log_data_sql TEXT := TG_ARGV[5];
+    foreign_id INTEGER;
+    fqid_var TEXT;
+    new_fk_field_value INTEGER[];
+    log_value INTEGER;
+    old_own_value INTEGER;
+BEGIN
+    -- No need to process deleted instance without field
+    -- Value adding on update is processed in before-trigger
+    old_own_value := hstore(OLD) -> own_column;
+    IF old_own_value IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF (foreign_id_sql != '') THEN
+        EXECUTE format(foreign_id_sql) INTO foreign_id USING OLD;
+        IF foreign_id IS NULL THEN
+            RETURN NULL;
+        END IF;
+    ELSE
+        foreign_id := hstore(OLD) -> own_column;
+    END IF;
+
+    IF (column_with_log_data != '') THEN
+        log_value := hstore(OLD) -> column_with_log_data;
+    ELSE
+        EXECUTE format(foreign_id_sql) INTO log_value USING OLD;
+    END IF;
+
+    IF log_value IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    EXECUTE format('SELECT %I from "%I" where id = %L', fk_field, foreign_table, foreign_id) INTO new_fk_field_value;
+    IF new_fk_field_value IS NOT NULL AND NOT (log_value = ANY(new_fk_field_value)) THEN
+        fqid_var := foreign_table || '/' || foreign_id;
+        CALL log_field_change('update', fqid_var, ARRAY[fk_field]);
+    END IF;
+
+    RETURN NULL;
+END;
+$log_modified_calculated_array_field_trigger$ LANGUAGE plpgsql;
+
+
 CREATE TABLE os_notify_log_t (
     id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     operation varchar(32),
@@ -5384,6 +5503,81 @@ CREATE CONSTRAINT TRIGGER equal_meeting_id_on_option_t_vote_ids AFTER INSERT ON 
 FOR EACH ROW EXECUTE FUNCTION check_equals('vote', 'option', 'option_id', 'meeting_id', TRUE);
 
 
+-- TODO: ensure all these names are unique
+--
+-- CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
+-- BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+-- FOR EACH ROW
+-- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+--     'committee',
+--     'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+--     'user_ids',
+--     'meeting_id',
+--     'user_id',
+--     ''
+-- );
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'committee',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+--
+-- CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
+-- BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
+-- FOR EACH ROW
+-- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+--     'committee',
+--     '',
+--     'user_ids',
+--     'committee_id',
+--     'user_id',
+--     ''
+-- );
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
+AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'committee',
+    '',
+    'user_ids',
+    'committee_id',
+    'user_id',
+    ''
+);
+
+--
+-- CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
+-- BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+-- FOR EACH ROW
+-- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+--     'committee',
+--     '',
+--     'user_ids',
+--     'home_committee_id',
+--     'id',
+--     ''
+-- );
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
+AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'committee',
+    '',
+    'user_ids',
+    'home_committee_id',
+    'id',
+    ''
+);
 
 /*   Relation-list infos
 Generated: What will be generated for left field

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -269,6 +269,21 @@ BEGIN
 END;
 $log_modified_related_trigger$ LANGUAGE plpgsql;
 
+CREATE TABLE os_notify_log_t (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    operation varchar(32),
+    fqid varchar(256) NOT NULL,
+    updated_fields varchar(63)[],
+    xact_id xid8,
+    timestamp timestamptz,
+    CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
+);
+
+CREATE TABLE version (
+    migration_index INTEGER PRIMARY KEY,
+    migration_state TEXT,
+    replace_tables JSONB
+);
 
 CREATE OR REPLACE FUNCTION iu_log_modified_calculated_id_array_field()
 RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
@@ -406,22 +421,6 @@ BEGIN
 END;
 $log_modified_calculated_id_array_field_trigger$ LANGUAGE plpgsql;
 
-
-CREATE TABLE os_notify_log_t (
-    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    operation varchar(32),
-    fqid varchar(256) NOT NULL,
-    updated_fields varchar(63)[],
-    xact_id xid8,
-    timestamp timestamptz,
-    CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
-);
-
-CREATE TABLE version (
-    migration_index INTEGER PRIMARY KEY,
-    migration_state TEXT,
-    replace_tables JSONB
-);
 
 CREATE OR REPLACE FUNCTION prevent_writes() RETURNS trigger AS $read_only_trigger$
 BEGIN

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -4209,6 +4209,87 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 CREATE TRIGGER tr_log_committee_t_default_meeting_id AFTER INSERT OR UPDATE OF default_meeting_id OR DELETE ON committee_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting', 'default_meeting_id', 'default_meeting_for_committee_id');
 
+-- committee.user_ids
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'committee',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'committee',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+--
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
+BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'committee',
+    'committee_id',
+    '',
+    'user_ids',
+    'committee_id',
+    'user_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
+AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'committee',
+    'committee_id',
+    '',
+    'user_ids',
+    'committee_id',
+    'user_id',
+    ''
+);
+
+--
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
+BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'committee',
+    'home_committee_id',
+    '',
+    'user_ids',
+    'home_committee_id',
+    'id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
+AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'committee',
+    'home_committee_id',
+    '',
+    'user_ids',
+    'home_committee_id',
+    'id',
+    ''
+);
+
 CREATE TRIGGER tr_log_nm_committee_manager_ids_user_t AFTER INSERT OR UPDATE OR DELETE ON nm_committee_manager_ids_user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee','committee_id','manager_ids','user','user_id','committee_management_ids');
 CREATE CONSTRAINT TRIGGER notify_transaction_end AFTER INSERT OR UPDATE OR DELETE ON nm_committee_manager_ids_user_t
@@ -4407,6 +4488,34 @@ CREATE TRIGGER tr_log_nm_meeting_present_user_ids_user_t AFTER INSERT OR UPDATE 
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting','meeting_id','present_user_ids','user','user_id','is_present_in_meeting_ids');
 CREATE CONSTRAINT TRIGGER notify_transaction_end AFTER INSERT OR UPDATE OR DELETE ON nm_meeting_present_user_ids_user_t
 DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_end();
+
+-- meeting.user_ids
+CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'meeting',
+    'meeting_id',
+    '',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'meeting',
+    'meeting_id',
+    '',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
 CREATE TRIGGER tr_log_meeting_t_reference_projector_id AFTER INSERT OR UPDATE OF reference_projector_id OR DELETE ON meeting_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('projector', 'reference_projector_id', 'used_as_reference_projector_meeting_id');
 CREATE TRIGGER tr_log_meeting_t_list_of_speakers_countdown_id AFTER INSERT OR UPDATE OF list_of_speakers_countdown_id OR DELETE ON meeting_t
@@ -4910,8 +5019,119 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 
 CREATE TRIGGER tr_log_user_t_gender_id AFTER INSERT OR UPDATE OF gender_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('gender', 'gender_id', 'user_ids');
+
+--  user.committee_ids
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'meeting_id',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'meeting_id',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
+);
+
+--
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_nm_committee_manager_ids_user_t
+BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'committee_id',
+    'committee_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_nm_committee_manager_ids_user_t
+AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'committee_id',
+    'committee_id',
+    ''
+);
+
+--
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t
+BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'id',
+    '',
+    'committee_ids',
+    'home_committee_id',
+    'home_committee_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t
+AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'id',
+    '',
+    'committee_ids',
+    'home_committee_id',
+    'home_committee_id',
+    ''
+);
+
 CREATE TRIGGER tr_log_user_t_home_committee_id AFTER INSERT OR UPDATE OF home_committee_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee', 'home_committee_id', 'native_user_ids');
+
+
+-- user.meeting_ids
+CREATE TRIGGER tr_iu_log_user_meeting_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'meeting_ids',
+    'user_id',
+    'meeting_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'meeting_ids',
+    'user_id',
+    'meeting_id',
+    ''
+);
+
 CREATE TRIGGER tr_log_user_t_organization_id AFTER INSERT OR UPDATE OF organization_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('organization', 'organization_id', 'user_ids');
 
@@ -5522,223 +5742,6 @@ CREATE CONSTRAINT TRIGGER equal_meeting_id_on_option_t_vote_ids AFTER INSERT ON 
 FOR EACH ROW EXECUTE FUNCTION check_equals('vote', 'option', 'option_id', 'meeting_id', TRUE);
 
 
--- TODO: ensure all these names are unique
--- Maybe we can omit update if fields are required and constant? Also relevant for nm
--- committee.user_ids
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
-BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    'committee_id',
-    '',
-    'user_ids',
-    'committee_id',
-    'user_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
-AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    'committee_id',
-    '',
-    'user_ids',
-    'committee_id',
-    'user_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
-BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    'home_committee_id',
-    '',
-    'user_ids',
-    'home_committee_id',
-    'id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
-AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    'home_committee_id',
-    '',
-    'user_ids',
-    'home_committee_id',
-    'id',
-    ''
-);
-
---  user.committee_ids
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'meeting_id',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'meeting_id',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
-);
-
---
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_nm_committee_manager_ids_user_t
-BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'committee_id',
-    'committee_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_nm_committee_manager_ids_user_t
-AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'committee_id',
-    'committee_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t
-BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'id',
-    '',
-    'committee_ids',
-    'home_committee_id',
-    'home_committee_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t
-AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'id',
-    '',
-    'committee_ids',
-    'home_committee_id',
-    'home_committee_id',
-    ''
-);
-
--- meeting.user_ids
-CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'meeting',
-    'meeting_id',
-    '',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'meeting',
-    'meeting_id',
-    '',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
--- user.meeting_ids
-CREATE TRIGGER tr_iu_log_user_meeting_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'meeting_ids',
-    'user_id',
-    'meeting_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'meeting_ids',
-    'user_id',
-    'meeting_id',
-    ''
-);
 
 /*   Relation-list infos
 Generated: What will be generated for left field

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -316,7 +316,7 @@ BEGIN
         RETURN NEW;
     END IF;
 
-    -- No value if column used for log_field -> return
+    -- No value in column used for log_field -> return
     IF (added_item_sql <> '') THEN
         EXECUTE added_item_sql INTO added_item USING NEW;
     ELSE
@@ -384,9 +384,9 @@ BEGIN
         RETURN NULL;
     END IF;
 
-    -- No value if column used for log_field -> return
+    -- No value in column used for log_field -> return
     IF (deleted_item_sql <> '') THEN
-        EXECUTE log_collection_id_sql INTO deleted_item USING OLD;
+        EXECUTE deleted_item_sql INTO deleted_item USING OLD;
     ELSE
         deleted_item := old_hstore -> deleted_item_column;
     END IF;
@@ -5611,12 +5611,12 @@ BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'user',
+    'user_id',
     '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
     'committee_ids',
     'meeting_id',
-    'user_id',
-    ''
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
 );
 
 CREATE TRIGGER tr_ud_log_user_committee_ids_from_meeting_user_t
@@ -5624,12 +5624,12 @@ AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
 FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'user',
+    'user_id',
     '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
     'committee_ids',
     'meeting_id',
-    'user_id',
-    ''
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
 );
 
 --
@@ -5701,7 +5701,7 @@ EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
 );
 
 CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
 FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'meeting',
@@ -5728,7 +5728,7 @@ EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
 );
 
 CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
 FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'user',

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -3059,7 +3059,8 @@ CREATE VIEW "committee" AS SELECT *,
     UNION
 
     -- Select user_id from home committees
-    SELECT u.id FROM user_t u
+    SELECT u.id
+    FROM user_t u
     WHERE u.home_committee_id = c.id
   ) _
 ) AS user_ids

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -5605,9 +5605,86 @@ EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     ''
 );
 
--- -- -- -- -- -- -- -- --
---  user.committee_ids  --
--- -- -- -- -- -- -- -- --
+--  user.committee_ids
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'committee_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'committee_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+--
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_nm_committee_manager_ids_user_t
+BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'committee_id',
+    'committee_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_nm_committee_manager_ids_user_t
+AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'user_id',
+    '',
+    'committee_ids',
+    'committee_id',
+    'committee_id',
+    ''
+);
+
+--
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t
+BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
+    'user',
+    'id',
+    '',
+    'committee_ids',
+    'home_committee_id',
+    'home_committee_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t
+AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'user',
+    'id',
+    '',
+    'committee_ids',
+    'home_committee_id',
+    'home_committee_id',
+    ''
+);
 
 -- meeting.user_ids
 CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -5504,7 +5504,8 @@ FOR EACH ROW EXECUTE FUNCTION check_equals('vote', 'option', 'option_id', 'meeti
 
 
 -- TODO: ensure all these names are unique
---
+-- Maybe we can omit update if fields are required and constant? Also relevant for nm
+-- committee.user_ids
 CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
 BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
@@ -5576,6 +5577,60 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     'user_ids',
     'home_committee_id',
     'id',
+    ''
+);
+
+-- -- -- -- -- -- -- -- --
+--  user.committee_ids  --
+-- -- -- -- -- -- -- -- --
+
+-- meeting.user_ids
+CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+    'meeting',
+    '',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'meeting',
+    '',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
+);
+
+-- user.meeting_ids
+CREATE TRIGGER tr_iu_log_user_meeting_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+    'user',
+    '',
+    'meeting_ids',
+    'user_id',
+    'meeting_id',
+    ''
+);
+
+CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'user',
+    '',
+    'meeting_ids',
+    'user_id',
+    'meeting_id',
     ''
 );
 

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -116,6 +116,24 @@ END;
 $sequences_trigger$
 LANGUAGE plpgsql;
 
+CREATE TABLE os_notify_log_t (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    operation varchar(32),
+    fqid varchar(256) NOT NULL,
+    updated_fields varchar(63)[],
+    xact_id xid8,
+    timestamp timestamptz,
+    CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
+);
+
+CREATE TABLE version (
+    migration_index INTEGER PRIMARY KEY,
+    migration_state TEXT,
+    replace_tables JSONB
+);
+
+-- Log functions
+
 CREATE OR REPLACE PROCEDURE log_field_change(
     operation_var TEXT,
     fqid_var TEXT,
@@ -167,39 +185,6 @@ BEGIN
     RETURN NULL;  -- returning NULL because AFTER TRIGGER return value is ignored
 END;
 $log_modified_trigger$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION is_timezone( tz TEXT ) RETURNS BOOLEAN as $$
-BEGIN
-    PERFORM now() AT TIME ZONE tz;
-    RETURN TRUE;
-EXCEPTION WHEN invalid_parameter_value THEN
-    RETURN FALSE;
-END;
-$$ language plpgsql STABLE;
-
-CREATE FUNCTION check_unique_ids_pair()
-RETURNS trigger
-AS $unique_ids_pair_trigger$
--- usage with 1 parameter IN TRIGGER DEFINITION:
--- base_column_name: name of write fields before adding numeric suffixes
--- Guards against mirrored duplicates by skipping one of the pairs.
-DECLARE
-    base_column_name text;
-    value_1 integer;
-    value_2 integer;
-BEGIN
-    base_column_name := TG_ARGV[0];
-    value_1 := hstore(NEW) -> (base_column_name || '_1');
-    value_2 := hstore(NEW) -> (base_column_name || '_2');
-
-    IF (value_1 > value_2) THEN
-        RETURN NULL;
-    END IF;
-
-    RETURN NEW;
-END;
-$unique_ids_pair_trigger$
-LANGUAGE plpgsql;
 
 CREATE FUNCTION notify_transaction_end() RETURNS trigger AS $notify_trigger$
 DECLARE
@@ -268,22 +253,6 @@ BEGIN
     RETURN NULL;  -- returning NULL because AFTER TRIGGER return value is ignored
 END;
 $log_modified_related_trigger$ LANGUAGE plpgsql;
-
-CREATE TABLE os_notify_log_t (
-    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    operation varchar(32),
-    fqid varchar(256) NOT NULL,
-    updated_fields varchar(63)[],
-    xact_id xid8,
-    timestamp timestamptz,
-    CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
-);
-
-CREATE TABLE version (
-    migration_index INTEGER PRIMARY KEY,
-    migration_state TEXT,
-    replace_tables JSONB
-);
 
 CREATE OR REPLACE FUNCTION log_iu_modified_calculated_id_array_field()
 RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
@@ -421,6 +390,40 @@ BEGIN
 END;
 $log_modified_calculated_id_array_field_trigger$ LANGUAGE plpgsql;
 
+-- Validation triggers
+
+CREATE OR REPLACE FUNCTION is_timezone( tz TEXT ) RETURNS BOOLEAN as $$
+BEGIN
+    PERFORM now() AT TIME ZONE tz;
+    RETURN TRUE;
+EXCEPTION WHEN invalid_parameter_value THEN
+    RETURN FALSE;
+END;
+$$ language plpgsql STABLE;
+
+CREATE FUNCTION check_unique_ids_pair()
+RETURNS trigger
+AS $unique_ids_pair_trigger$
+-- usage with 1 parameter IN TRIGGER DEFINITION:
+-- base_column_name: name of write fields before adding numeric suffixes
+-- Guards against mirrored duplicates by skipping one of the pairs.
+DECLARE
+    base_column_name text;
+    value_1 integer;
+    value_2 integer;
+BEGIN
+    base_column_name := TG_ARGV[0];
+    value_1 := hstore(NEW) -> (base_column_name || '_1');
+    value_2 := hstore(NEW) -> (base_column_name || '_2');
+
+    IF (value_1 > value_2) THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN NEW;
+END;
+$unique_ids_pair_trigger$
+LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION prevent_writes() RETURNS trigger AS $read_only_trigger$
 BEGIN

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -288,48 +288,50 @@ $log_modified_related_trigger$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION iu_log_modified_calculated_array_field()
 RETURNS trigger AS $log_modified_calculated_array_field_trigger$
 DECLARE
-    foreign_table TEXT := TG_ARGV[0];  -- Collection for which the log entry should be written
-    foreign_id_sql TEXT := TG_ARGV[1];  -- Custom SQL to get id for `foreign_table`
-    fk_field TEXT := TG_ARGV[2];  -- Field for which the log entry should be written
-    own_column TEXT := TG_ARGV[3];  -- Change of value in this must fire log trigger
-    column_with_log_data TEXT := TG_ARGV[4];  -- Value that will be added (or not) to the calculated field
-    log_data_sql TEXT := TG_ARGV[5];  -- Custom SQL to get value for the calculated field
-    foreign_id INTEGER;  -- Id of `foreign_table` for which the log entry should be written
+    log_collection TEXT := TG_ARGV[0];  -- Collection for which the log entry should be written
+    log_collection_id_sql TEXT := TG_ARGV[1];  -- Custom SQL to get id for `log_collection`
+    log_collection_id_field TEXT := TG_ARGV[2];  -- Custom SQL to get id for `log_collection`
+    log_field TEXT := TG_ARGV[3];  -- Field for which the log entry should be written
+    trigger_field TEXT := TG_ARGV[4];  -- Change of value in this must fire log trigger
+    deleted_item_column_name TEXT := TG_ARGV[5];  -- Value that will be added (or not) to the calculated field
+    deleted_item_sql TEXT := TG_ARGV[6];  -- Custom SQL to get value for the calculated field
+
+    log_collection_id INTEGER;  -- Id of `log_collection` for which the log entry should be written
     fqid_var TEXT;  -- Parameter 1 to log function
-    old_fk_field_value INTEGER[]; -- Old value of the calculated field
-    log_value INTEGER;  -- Must become the part of calculated field after the transaction
-    new_own_value INTEGER;
+    old_log_field_value INTEGER[]; -- Old value of the calculated field
+    added_item INTEGER;  -- Must become the part of calculated field after the transaction
+    new_trigger_value INTEGER;
 BEGIN
     -- No need to process new instance without field
     -- Value deletion on update is processed in after-trigger
-    new_own_value := hstore(NEW) -> own_column;
-    IF new_own_value IS NULL THEN
+    new_trigger_value := hstore(NEW) -> trigger_field;
+    IF new_trigger_value IS NULL THEN
         RETURN NEW;
     END IF;
 
-    IF (foreign_id_sql != '') THEN
-        EXECUTE format(foreign_id_sql) INTO foreign_id USING NEW;
-        IF foreign_id IS NULL THEN
+    IF (log_collection_id_sql != '') THEN
+        EXECUTE format(log_collection_id_sql) INTO log_collection_id USING NEW;
+        IF log_collection_id IS NULL THEN
             RETURN NEW;
         END IF;
     ELSE
-        foreign_id := hstore(NEW) -> own_column;
+        log_collection_id := hstore(NEW) -> log_collection_id_field;
     END IF;
 
-    IF (column_with_log_data != '') THEN
-        log_value := hstore(NEW) -> column_with_log_data;
+    IF (deleted_item_column_name != '') THEN
+        added_item := hstore(NEW) -> deleted_item_column_name;
     ELSE
-        EXECUTE format(foreign_id_sql) INTO log_value USING NEW;
+        EXECUTE format(log_collection_id_sql) INTO added_item USING NEW;
     END IF;
 
-    IF log_value IS NULL THEN
+    IF added_item IS NULL THEN
         RETURN NEW;
     END IF;
 
-    EXECUTE format('SELECT %I from "%I" where id = %L', fk_field, foreign_table, foreign_id) INTO old_fk_field_value;
-    IF old_fk_field_value IS NULL OR NOT (log_value = ANY(old_fk_field_value)) THEN
-        fqid_var := foreign_table || '/' || foreign_id;
-        CALL log_field_change('update', fqid_var, ARRAY[fk_field]);
+    EXECUTE format('SELECT %I from "%I" where id = %L', log_field, log_collection, log_collection_id) INTO old_log_field_value;
+    IF old_log_field_value IS NULL OR NOT (added_item = ANY(old_log_field_value)) THEN
+        fqid_var := log_collection || '/' || log_collection_id;
+        CALL log_field_change('update', fqid_var, ARRAY[log_field]);
     END IF;
 
     RETURN NEW;
@@ -339,48 +341,50 @@ $log_modified_calculated_array_field_trigger$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION ud_log_modified_calculated_array_field()
 RETURNS trigger AS $log_modified_calculated_array_field_trigger$
 DECLARE
-    foreign_table TEXT := TG_ARGV[0];
-    foreign_id_sql TEXT := TG_ARGV[1];
-    fk_field TEXT := TG_ARGV[2];
-    own_column TEXT := TG_ARGV[3];
-    column_with_log_data TEXT := TG_ARGV[4];
-    log_data_sql TEXT := TG_ARGV[5];
-    foreign_id INTEGER;
+    log_collection TEXT := TG_ARGV[0];
+    log_collection_id_sql TEXT := TG_ARGV[1];
+    log_collection_id_field TEXT := TG_ARGV[2];
+    log_field TEXT := TG_ARGV[3];
+    trigger_field TEXT := TG_ARGV[4];
+    deleted_item_column_name TEXT := TG_ARGV[5];
+    deleted_item_sql TEXT := TG_ARGV[6];
+
+    log_collection_id INTEGER;
     fqid_var TEXT;
-    new_fk_field_value INTEGER[];
-    log_value INTEGER;
-    old_own_value INTEGER;
+    new_deleted_item_value INTEGER[];
+    deleted_item INTEGER;
+    old_trigger_value INTEGER;
 BEGIN
     -- No need to process deleted instance without field
     -- Value adding on update is processed in before-trigger
-    old_own_value := hstore(OLD) -> own_column;
-    IF old_own_value IS NULL THEN
+    old_trigger_value := hstore(OLD) -> trigger_field;
+    IF old_trigger_value IS NULL THEN
         RETURN NULL;
     END IF;
 
-    IF (foreign_id_sql != '') THEN
-        EXECUTE format(foreign_id_sql) INTO foreign_id USING OLD;
-        IF foreign_id IS NULL THEN
+    IF (log_collection_id_sql != '') THEN
+        EXECUTE format(log_collection_id_sql) INTO log_collection_id USING OLD;
+        IF log_collection_id IS NULL THEN
             RETURN NULL;
         END IF;
     ELSE
-        foreign_id := hstore(OLD) -> own_column;
+        foreign_id := hstore(OLD) -> log_collection_id_field;
     END IF;
 
-    IF (column_with_log_data != '') THEN
-        log_value := hstore(OLD) -> column_with_log_data;
+    IF (deleted_item_column_name != '') THEN
+        deleted_item := hstore(OLD) -> deleted_item_column_name;
     ELSE
-        EXECUTE format(foreign_id_sql) INTO log_value USING OLD;
+        EXECUTE format(log_collection_id_sql) INTO deleted_item USING OLD;
     END IF;
 
-    IF log_value IS NULL THEN
+    IF deleted_item IS NULL THEN
         RETURN NULL;
     END IF;
 
-    EXECUTE format('SELECT %I from "%I" where id = %L', fk_field, foreign_table, foreign_id) INTO new_fk_field_value;
-    IF new_fk_field_value IS NULL OR NOT (log_value = ANY(new_fk_field_value)) THEN
-        fqid_var := foreign_table || '/' || foreign_id;
-        CALL log_field_change('update', fqid_var, ARRAY[fk_field]);
+    EXECUTE format('SELECT %I from "%I" where id = %L', log_field, log_collection, log_collection_id) INTO new_deleted_item_value;
+    IF new_deleted_item_value IS NULL OR NOT (deleted_item = ANY(new_deleted_item_value)) THEN
+        fqid_var := log_collection || '/' || log_collection_id;
+        CALL log_field_change('update', fqid_var, ARRAY[log_field]);
     END IF;
 
     RETURN NULL;
@@ -5512,6 +5516,7 @@ FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'committee',
     'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    '',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5522,12 +5527,13 @@ CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
 AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
 FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_array_field(
-    'committee',                                                      -- foreign_table
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',  -- foreign_id_sql
-    'user_ids',                                                       -- fk_field
-    'meeting_id',                                                     -- own_column
-    'user_id',                                                        -- column_with_log_data
-    ''                                                                -- log_data_sql
+    'committee',                                                      -- log_collection
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',  -- log_collection_id_sql
+    '',                                                               -- log_collection_id_field
+    'user_ids',                                                       -- log_field
+    'meeting_id',                                                     -- trigger_field
+    'user_id',                                                        -- deleted_item_column_name
+    ''                                                                -- deleted_item_sql
 );
 
 --
@@ -5537,6 +5543,7 @@ FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'committee',
     '',
+    'committee_id',
     'user_ids',
     'committee_id',
     'user_id',
@@ -5549,6 +5556,7 @@ FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     'committee',
     '',
+    'committee_id',
     'user_ids',
     'committee_id',
     'user_id',
@@ -5562,6 +5570,7 @@ FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'committee',
     '',
+    'home_committee_id',
     'user_ids',
     'home_committee_id',
     'id',
@@ -5574,6 +5583,7 @@ FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     'committee',
     '',
+    'home_committee_id',
     'user_ids',
     'home_committee_id',
     'id',
@@ -5591,6 +5601,7 @@ FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'meeting',
     '',
+    'meeting_id',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5603,6 +5614,7 @@ FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     'meeting',
     '',
+    'meeting_id',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5616,6 +5628,7 @@ FOR EACH ROW
 EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'user',
     '',
+    'user_id',
     'meeting_ids',
     'user_id',
     'meeting_id',
@@ -5628,6 +5641,7 @@ FOR EACH ROW
 EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     'user',
     '',
+    'user_id',
     'meeting_ids',
     'user_id',
     'meeting_id',

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -1,7 +1,7 @@
 
 -- schema_relational.sql for initial database setup OpenSlides
 -- Code generated. DO NOT EDIT.
--- MODELS_YML_CHECKSUM = '967255cf67d7c6453418c1631eb84113'
+-- MODELS_YML_CHECKSUM = 'befdc1a8ac45dfa1b9f84391dca75340'
 
 
 -- ENUM definitions

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -269,66 +269,66 @@ BEGIN
 END;
 $log_modified_related_trigger$ LANGUAGE plpgsql;
 
--- If insert:
-    -- If field is null -> skip
-    -- Else:
-        -- In before trigger (New value is not null) -> log if not present in OLD.calculated field
--- If update:
-    -- If old and new are same -> skip (checked by the definition `update of column_name`)
-    -- Else:
-        -- In before trigger: If New value is not null -> log if not present in OLD.calculated field
-        -- In after trigger: If New value is null (Old value is not null) -> log if not present in NEW.calculated field
--- If delete:
-    -- If Old value is null -> skip
-    -- Else:
-        -- In after trigger (Old value is not null) -> log if not present in NEW.calculated field
 
-
--- Not just arrays, but ids_arrays.. Make the name more short and precise
-CREATE OR REPLACE FUNCTION iu_log_modified_calculated_array_field()
-RETURNS trigger AS $log_modified_calculated_array_field_trigger$
+CREATE OR REPLACE FUNCTION iu_log_modified_calculated_id_array_field()
+RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
+-- Expects in this order:
+-- 0. log_collection – Target collection for the log entry
+-- 1. log_collection_id_column – Column used to fetch the 'log_collection' id
+--    (ignored if 'log_collection_id_sql' is provided => may be NULL)
+-- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
+-- 3. log_field – Field to be logged
+-- 4. trigger_column – Column whose change triggers logging
+-- 5. added_item_column – Column used to fetch the value added to 'log_field'
+--    (ignored if 'added_item_sql' is provided => may be NULL)
+-- 6. added_item_sql – Custom SQL to fetch the value added to 'log_field'
 DECLARE
-    log_collection TEXT := TG_ARGV[0];  -- Collection for which the log entry should be written
-    log_collection_id_sql TEXT := TG_ARGV[1];  -- Custom SQL to get id for `log_collection`
-    log_collection_id_field TEXT := TG_ARGV[2];  -- Custom SQL to get id for `log_collection`
-    log_field TEXT := TG_ARGV[3];  -- Field for which the log entry should be written
-    trigger_field TEXT := TG_ARGV[4];  -- Change of value in this must fire log trigger
-    deleted_item_column_name TEXT := TG_ARGV[5];  -- Value that will be added (or not) to the calculated field
-    deleted_item_sql TEXT := TG_ARGV[6];  -- Custom SQL to get value for the calculated field
+    log_collection TEXT := TG_ARGV[0];
+    log_collection_id_column TEXT := TG_ARGV[1];
+    log_collection_id_sql TEXT := TG_ARGV[2];
+    log_field TEXT := TG_ARGV[3];
+    trigger_column TEXT := TG_ARGV[4];
+    added_item_column TEXT := TG_ARGV[5];
+    added_item_sql TEXT := TG_ARGV[6];
 
-    log_collection_id INTEGER;  -- Id of `log_collection` for which the log entry should be written
-    fqid_var TEXT;  -- Parameter 1 to log function
-    old_log_field_value INTEGER[]; -- Old value of the calculated field
-    added_item INTEGER;  -- Must become the part of calculated field after the transaction
+    new_hstore hstore := hstore(NEW);
     new_trigger_value INTEGER;
+    log_collection_id INTEGER;
+    added_item INTEGER;
+    old_log_field_value INTEGER[];
+    fqid_var TEXT;
 BEGIN
     -- No need to process new instance without field
     -- Value deletion on update is processed in after-trigger
-    new_trigger_value := hstore(NEW) -> trigger_field;
+    new_trigger_value := new_hstore -> trigger_column;
     IF new_trigger_value IS NULL THEN
         RETURN NEW;
     END IF;
 
-    IF (log_collection_id_sql != '') THEN
-        EXECUTE format(log_collection_id_sql) INTO log_collection_id USING NEW;
-        IF log_collection_id IS NULL THEN
-            RETURN NEW;
-        END IF;
+    -- Related log_collection item is not updated -> return
+    IF (log_collection_id_sql <> '') THEN
+        EXECUTE log_collection_id_sql INTO log_collection_id USING NEW;
     ELSE
-        log_collection_id := hstore(NEW) -> log_collection_id_field;
+        log_collection_id := new_hstore -> log_collection_id_column;
     END IF;
 
-    IF (deleted_item_column_name != '') THEN
-        added_item := hstore(NEW) -> deleted_item_column_name;
+    IF log_collection_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- No value if column used for log_field -> return
+    IF (added_item_sql <> '') THEN
+        EXECUTE added_item_sql INTO added_item USING NEW;
     ELSE
-        EXECUTE format(log_collection_id_sql) INTO added_item USING NEW;
+        added_item := new_hstore -> added_item_column;
     END IF;
 
     IF added_item IS NULL THEN
         RETURN NEW;
     END IF;
 
-    EXECUTE format('SELECT %I from "%I" where id = %L', log_field, log_collection, log_collection_id) INTO old_log_field_value;
+    -- Add log entry only if log_field value actually changes
+    EXECUTE format('SELECT %I from %I where id = %L', log_field, log_collection, log_collection_id) INTO old_log_field_value;
     IF old_log_field_value IS NULL OR NOT (added_item = ANY(old_log_field_value)) THEN
         fqid_var := log_collection || '/' || log_collection_id;
         CALL log_field_change('update', fqid_var, ARRAY[log_field]);
@@ -336,60 +336,75 @@ BEGIN
 
     RETURN NEW;
 END;
-$log_modified_calculated_array_field_trigger$ LANGUAGE plpgsql;
+$log_modified_calculated_id_array_field_trigger$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION ud_log_modified_calculated_array_field()
-RETURNS trigger AS $log_modified_calculated_array_field_trigger$
+CREATE OR REPLACE FUNCTION ud_log_modified_calculated_id_array_field()
+RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
+-- Expects in this order:
+-- 0. log_collection – Target collection for the log entry
+-- 1. log_collection_id_column – Column used to fetch the 'log_collection' id
+--    (ignored if 'log_collection_id_sql' is provided => may be NULL)
+-- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
+-- 3. log_field – Field to be logged
+-- 4. trigger_column – Column whose change triggers logging
+-- 5. deleted_item_column – Column used to fetch the value deleted from 'log_field'
+--    (ignored if 'deleted_item_sql' is provided => may be NULL)
+-- 6. deleted_item_sql – Custom SQL to fetch the value deleted from 'log_field'
 DECLARE
     log_collection TEXT := TG_ARGV[0];
-    log_collection_id_sql TEXT := TG_ARGV[1];
-    log_collection_id_field TEXT := TG_ARGV[2];
+    log_collection_id_column TEXT := TG_ARGV[1];
+    log_collection_id_sql TEXT := TG_ARGV[2];
     log_field TEXT := TG_ARGV[3];
-    trigger_field TEXT := TG_ARGV[4];
-    deleted_item_column_name TEXT := TG_ARGV[5];
+    trigger_column TEXT := TG_ARGV[4];
+    deleted_item_column TEXT := TG_ARGV[5];
     deleted_item_sql TEXT := TG_ARGV[6];
 
-    log_collection_id INTEGER;
-    fqid_var TEXT;
-    new_deleted_item_value INTEGER[];
-    deleted_item INTEGER;
+    old_hstore hstore := hstore(OLD);
     old_trigger_value INTEGER;
+    log_collection_id INTEGER;
+    deleted_item INTEGER;
+    new_log_field_value INTEGER[];
+    fqid_var TEXT;
 BEGIN
     -- No need to process deleted instance without field
     -- Value adding on update is processed in before-trigger
-    old_trigger_value := hstore(OLD) -> trigger_field;
+    old_trigger_value := old_hstore -> trigger_column;
     IF old_trigger_value IS NULL THEN
         RETURN NULL;
     END IF;
 
-    IF (log_collection_id_sql != '') THEN
-        EXECUTE format(log_collection_id_sql) INTO log_collection_id USING OLD;
-        IF log_collection_id IS NULL THEN
-            RETURN NULL;
-        END IF;
+    -- Related log_collection item is not updated -> return
+    IF (log_collection_id_sql <> '') THEN
+        EXECUTE log_collection_id_sql INTO log_collection_id USING OLD;
     ELSE
-        foreign_id := hstore(OLD) -> log_collection_id_field;
+        log_collection_id := old_hstore -> log_collection_id_column;
     END IF;
 
-    IF (deleted_item_column_name != '') THEN
-        deleted_item := hstore(OLD) -> deleted_item_column_name;
+    IF log_collection_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- No value if column used for log_field -> return
+    IF (deleted_item_sql <> '') THEN
+        EXECUTE log_collection_id_sql INTO deleted_item USING OLD;
     ELSE
-        EXECUTE format(log_collection_id_sql) INTO deleted_item USING OLD;
+        deleted_item := old_hstore -> deleted_item_column;
     END IF;
 
     IF deleted_item IS NULL THEN
         RETURN NULL;
     END IF;
 
-    EXECUTE format('SELECT %I from "%I" where id = %L', log_field, log_collection, log_collection_id) INTO new_deleted_item_value;
-    IF new_deleted_item_value IS NULL OR NOT (deleted_item = ANY(new_deleted_item_value)) THEN
+    -- Add log entry only if log_field value actually changes
+    EXECUTE format('SELECT %I from %I where id = %L', log_field, log_collection, log_collection_id) INTO new_log_field_value;
+    IF new_log_field_value IS NULL OR NOT (deleted_item = ANY(new_log_field_value)) THEN
         fqid_var := log_collection || '/' || log_collection_id;
         CALL log_field_change('update', fqid_var, ARRAY[log_field]);
     END IF;
 
     RETURN NULL;
 END;
-$log_modified_calculated_array_field_trigger$ LANGUAGE plpgsql;
+$log_modified_calculated_id_array_field_trigger$ LANGUAGE plpgsql;
 
 
 CREATE TABLE os_notify_log_t (
@@ -5513,10 +5528,10 @@ FOR EACH ROW EXECUTE FUNCTION check_equals('vote', 'option', 'option_id', 'meeti
 CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
 BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'committee',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
     '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5526,24 +5541,24 @@ EXECUTE FUNCTION iu_log_modified_calculated_array_field(
 CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
 AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
-    'committee',                                                      -- log_collection
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',  -- log_collection_id_sql
-    '',                                                               -- log_collection_id_field
-    'user_ids',                                                       -- log_field
-    'meeting_id',                                                     -- trigger_field
-    'user_id',                                                        -- deleted_item_column_name
-    ''                                                                -- deleted_item_sql
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
+    'committee',
+    '',
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
+    'user_ids',
+    'meeting_id',
+    'user_id',
+    ''
 );
 
 --
 CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
 BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
 FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'committee',
-    '',
     'committee_id',
+    '',
     'user_ids',
     'committee_id',
     'user_id',
@@ -5553,10 +5568,10 @@ EXECUTE FUNCTION iu_log_modified_calculated_array_field(
 CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
 AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'committee',
-    '',
     'committee_id',
+    '',
     'user_ids',
     'committee_id',
     'user_id',
@@ -5567,10 +5582,10 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
 CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
 BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
 FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'committee',
-    '',
     'home_committee_id',
+    '',
     'user_ids',
     'home_committee_id',
     'id',
@@ -5580,10 +5595,10 @@ EXECUTE FUNCTION iu_log_modified_calculated_array_field(
 CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
 AFTER UPDATE OF home_committee_id OR DELETE ON user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'committee',
-    '',
     'home_committee_id',
+    '',
     'user_ids',
     'home_committee_id',
     'id',
@@ -5598,10 +5613,10 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
 CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t
 BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'meeting',
-    '',
     'meeting_id',
+    '',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5611,10 +5626,10 @@ EXECUTE FUNCTION iu_log_modified_calculated_array_field(
 CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
 AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'meeting',
-    '',
     'meeting_id',
+    '',
     'user_ids',
     'meeting_id',
     'user_id',
@@ -5625,10 +5640,10 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
 CREATE TRIGGER tr_iu_log_user_meeting_ids_from_meeting_user_t
 BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
     'user',
-    '',
     'user_id',
+    '',
     'meeting_ids',
     'user_id',
     'meeting_id',
@@ -5638,10 +5653,10 @@ EXECUTE FUNCTION iu_log_modified_calculated_array_field(
 CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
 AFTER UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
     'user',
-    '',
     'user_id',
+    '',
     'meeting_ids',
     'user_id',
     'meeting_id',

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -1,7 +1,7 @@
 
 -- schema_relational.sql for initial database setup OpenSlides
 -- Code generated. DO NOT EDIT.
--- MODELS_YML_CHECKSUM = 'cb650b34fd00541dd72f24048dc17112'
+-- MODELS_YML_CHECKSUM = '967255cf67d7c6453418c1631eb84113'
 
 
 -- ENUM definitions
@@ -3059,7 +3059,8 @@ CREATE VIEW "committee" AS SELECT *,
     UNION
 
     -- Select user_id from home committees
-    SELECT u.id FROM user_t u WHERE u.home_committee_id = c.id
+    SELECT u.id FROM user_t u
+    WHERE u.home_committee_id = c.id
   ) _
 ) AS user_ids
 ,
@@ -4208,86 +4209,19 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 CREATE TRIGGER tr_log_committee_t_default_meeting_id AFTER INSERT OR UPDATE OF default_meeting_id OR DELETE ON committee_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting', 'default_meeting_id', 'default_meeting_for_committee_id');
 
--- committee.user_ids
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
+CREATE TRIGGER tr_i_log_committee_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_d_log_committee_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_i_log_committee_user_ids_from_nm_committee_manager_id05ef8b4 BEFORE INSERT ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+CREATE TRIGGER tr_d_log_committee_user_ids_from_nm_committee_manager_id9f17295 AFTER DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
 
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
-BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    'committee_id',
-    '',
-    'user_ids',
-    'committee_id',
-    'user_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
-AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    'committee_id',
-    '',
-    'user_ids',
-    'committee_id',
-    'user_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
-BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'committee',
-    'home_committee_id',
-    '',
-    'user_ids',
-    'home_committee_id',
-    'id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
-AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'committee',
-    'home_committee_id',
-    '',
-    'user_ids',
-    'home_committee_id',
-    'id',
-    ''
-);
 
 CREATE TRIGGER tr_log_nm_committee_manager_ids_user_t AFTER INSERT OR UPDATE OR DELETE ON nm_committee_manager_ids_user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee','committee_id','manager_ids','user','user_id','committee_management_ids');
@@ -4488,32 +4422,10 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting','meeting_id'
 CREATE CONSTRAINT TRIGGER notify_transaction_end AFTER INSERT OR UPDATE OR DELETE ON nm_meeting_present_user_ids_user_t
 DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_end();
 
--- meeting.user_ids
-CREATE TRIGGER tr_iu_log_meeting_user_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'meeting',
-    'meeting_id',
-    '',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_meeting_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'meeting',
-    'meeting_id',
-    '',
-    'user_ids',
-    'meeting_id',
-    'user_id',
-    ''
-);
+CREATE TRIGGER tr_i_log_meeting_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_d_log_meeting_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
 
 CREATE TRIGGER tr_log_meeting_t_reference_projector_id AFTER INSERT OR UPDATE OF reference_projector_id OR DELETE ON meeting_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('projector', 'reference_projector_id', 'used_as_reference_projector_meeting_id');
@@ -5019,117 +4931,26 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 CREATE TRIGGER tr_log_user_t_gender_id AFTER INSERT OR UPDATE OF gender_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('gender', 'gender_id', 'user_ids');
 
---  user.committee_ids
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'meeting_id',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'meeting_id',
-    '',
-    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id'
-);
-
---
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_nm_committee_manager_ids_user_t
-BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'committee_id',
-    'committee_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_nm_committee_manager_ids_user_t
-AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'committee_ids',
-    'committee_id',
-    'committee_id',
-    ''
-);
-
---
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t
-BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'id',
-    '',
-    'committee_ids',
-    'home_committee_id',
-    'home_committee_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t
-AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'id',
-    '',
-    'committee_ids',
-    'home_committee_id',
-    'home_committee_id',
-    ''
-);
+CREATE TRIGGER tr_i_log_user_committee_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+CREATE TRIGGER tr_d_log_user_committee_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+CREATE TRIGGER tr_i_log_user_committee_ids_from_nm_committee_manager_id3981725 BEFORE INSERT ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+CREATE TRIGGER tr_d_log_user_committee_ids_from_nm_committee_manager_id5460aae AFTER DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
+CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
 
 CREATE TRIGGER tr_log_user_t_home_committee_id AFTER INSERT OR UPDATE OF home_committee_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee', 'home_committee_id', 'native_user_ids');
 
-
--- user.meeting_ids
-CREATE TRIGGER tr_iu_log_user_meeting_ids_from_meeting_user_t
-BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION iu_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'meeting_ids',
-    'user_id',
-    'meeting_id',
-    ''
-);
-
-CREATE TRIGGER tr_ud_log_user_meeting_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
-FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_id_array_field(
-    'user',
-    'user_id',
-    '',
-    'meeting_ids',
-    'user_id',
-    'meeting_id',
-    ''
-);
+CREATE TRIGGER tr_i_log_user_meeting_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
+CREATE TRIGGER tr_d_log_user_meeting_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
 
 CREATE TRIGGER tr_log_user_t_organization_id AFTER INSERT OR UPDATE OF organization_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('organization', 'organization_id', 'user_ids');

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -285,7 +285,7 @@ CREATE TABLE version (
     replace_tables JSONB
 );
 
-CREATE OR REPLACE FUNCTION iu_log_modified_calculated_id_array_field()
+CREATE OR REPLACE FUNCTION log_iu_modified_calculated_id_array_field()
 RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
 -- Expects in this order:
 -- 0. log_collection – Target collection for the log entry
@@ -353,7 +353,7 @@ BEGIN
 END;
 $log_modified_calculated_id_array_field_trigger$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION ud_log_modified_calculated_id_array_field()
+CREATE OR REPLACE FUNCTION log_ud_modified_calculated_id_array_field()
 RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
 -- Expects in this order:
 -- 0. log_collection – Target collection for the log entry
@@ -4210,18 +4210,18 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 CREATE TRIGGER tr_log_committee_t_default_meeting_id AFTER INSERT OR UPDATE OF default_meeting_id OR DELETE ON committee_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting', 'default_meeting_id', 'default_meeting_for_committee_id');
 
-CREATE TRIGGER tr_i_log_committee_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
-CREATE TRIGGER tr_d_log_committee_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
-CREATE TRIGGER tr_i_log_committee_user_ids_from_nm_committee_manager_id05ef8b4 BEFORE INSERT ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
-CREATE TRIGGER tr_d_log_committee_user_ids_from_nm_committee_manager_id9f17295 AFTER DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
-CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
+CREATE TRIGGER tr_log_i_committee_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_log_d_committee_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_log_i_committee_user_ids_from_nm_committee_manager_idd4a2a53 BEFORE INSERT ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+CREATE TRIGGER tr_log_d_committee_user_ids_from_nm_committee_manager_id82dfd00 AFTER DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+CREATE TRIGGER tr_log_iu_committee_user_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
+CREATE TRIGGER tr_log_ud_committee_user_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
 
 
 CREATE TRIGGER tr_log_nm_committee_manager_ids_user_t AFTER INSERT OR UPDATE OR DELETE ON nm_committee_manager_ids_user_t
@@ -4423,10 +4423,10 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting','meeting_id'
 CREATE CONSTRAINT TRIGGER notify_transaction_end AFTER INSERT OR UPDATE OR DELETE ON nm_meeting_present_user_ids_user_t
 DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_end();
 
-CREATE TRIGGER tr_i_log_meeting_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
-CREATE TRIGGER tr_d_log_meeting_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_log_i_meeting_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
+CREATE TRIGGER tr_log_d_meeting_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
 
 CREATE TRIGGER tr_log_meeting_t_reference_projector_id AFTER INSERT OR UPDATE OF reference_projector_id OR DELETE ON meeting_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('projector', 'reference_projector_id', 'used_as_reference_projector_meeting_id');
@@ -4932,26 +4932,26 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_e
 CREATE TRIGGER tr_log_user_t_gender_id AFTER INSERT OR UPDATE OF gender_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('gender', 'gender_id', 'user_ids');
 
-CREATE TRIGGER tr_i_log_user_committee_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
-CREATE TRIGGER tr_d_log_user_committee_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
-CREATE TRIGGER tr_i_log_user_committee_ids_from_nm_committee_manager_id3981725 BEFORE INSERT ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
-CREATE TRIGGER tr_d_log_user_committee_ids_from_nm_committee_manager_id5460aae AFTER DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
-CREATE TRIGGER tr_iu_log_user_committee_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
-CREATE TRIGGER tr_ud_log_user_committee_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
+CREATE TRIGGER tr_log_i_user_committee_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+CREATE TRIGGER tr_log_d_user_committee_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+CREATE TRIGGER tr_log_i_user_committee_ids_from_nm_committee_manager_id3c34791 BEFORE INSERT ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+CREATE TRIGGER tr_log_d_user_committee_ids_from_nm_committee_manager_id8cfd923 AFTER DELETE ON nm_committee_manager_ids_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+CREATE TRIGGER tr_log_iu_user_committee_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
+CREATE TRIGGER tr_log_ud_user_committee_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
 
 CREATE TRIGGER tr_log_user_t_home_committee_id AFTER INSERT OR UPDATE OF home_committee_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee', 'home_committee_id', 'native_user_ids');
 
-CREATE TRIGGER tr_i_log_user_meeting_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION iu_log_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
-CREATE TRIGGER tr_d_log_user_meeting_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION ud_log_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
+CREATE TRIGGER tr_log_i_user_meeting_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
+CREATE TRIGGER tr_log_d_user_meeting_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
 
 CREATE TRIGGER tr_log_user_t_organization_id AFTER INSERT OR UPDATE OF organization_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('organization', 'organization_id', 'user_ids');

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -1,7 +1,7 @@
 
 -- schema_relational.sql for initial database setup OpenSlides
 -- Code generated. DO NOT EDIT.
--- MODELS_YML_CHECKSUM = 'befdc1a8ac45dfa1b9f84391dca75340'
+-- MODELS_YML_CHECKSUM = '1de0700134a3096c9686eca84111beae'
 
 
 -- ENUM definitions
@@ -262,34 +262,24 @@ RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
 --    (ignored if 'log_collection_id_sql' is provided => may be NULL)
 -- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
 -- 3. log_field – Field to be logged
--- 4. trigger_column – Column whose change triggers logging
--- 5. added_item_column – Column used to fetch the value added to 'log_field'
+-- 4. added_item_column – Column used to fetch the value added to 'log_field'
 --    (ignored if 'added_item_sql' is provided => may be NULL)
--- 6. added_item_sql – Custom SQL to fetch the value added to 'log_field'
+-- 5. added_item_sql – Custom SQL to fetch the value added to 'log_field'
 DECLARE
     log_collection TEXT := TG_ARGV[0];
     log_collection_id_column TEXT := TG_ARGV[1];
     log_collection_id_sql TEXT := TG_ARGV[2];
     log_field TEXT := TG_ARGV[3];
-    trigger_column TEXT := TG_ARGV[4];
-    added_item_column TEXT := TG_ARGV[5];
-    added_item_sql TEXT := TG_ARGV[6];
+    added_item_column TEXT := TG_ARGV[4];
+    added_item_sql TEXT := TG_ARGV[5];
 
     new_hstore hstore := hstore(NEW);
-    new_trigger_value INTEGER;
     log_collection_id INTEGER;
     added_item INTEGER;
     old_log_field_value INTEGER[];
     fqid_var TEXT;
 BEGIN
-    -- No need to process new instance without field
-    -- Value deletion on update is processed in after-trigger
-    new_trigger_value := new_hstore -> trigger_column;
-    IF new_trigger_value IS NULL THEN
-        RETURN NEW;
-    END IF;
-
-    -- Related log_collection item is not updated -> return
+    -- No related log_collection instance -> return
     IF (log_collection_id_sql <> '') THEN
         EXECUTE log_collection_id_sql INTO log_collection_id USING NEW;
     ELSE
@@ -301,6 +291,7 @@ BEGIN
     END IF;
 
     -- No value in column used for log_field -> return
+    -- Value deletion on update is processed in after-trigger
     IF (added_item_sql <> '') THEN
         EXECUTE added_item_sql INTO added_item USING NEW;
     ELSE
@@ -330,34 +321,24 @@ RETURNS trigger AS $log_modified_calculated_id_array_field_trigger$
 --    (ignored if 'log_collection_id_sql' is provided => may be NULL)
 -- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
 -- 3. log_field – Field to be logged
--- 4. trigger_column – Column whose change triggers logging
--- 5. deleted_item_column – Column used to fetch the value deleted from 'log_field'
+-- 4. deleted_item_column – Column used to fetch the value deleted from 'log_field'
 --    (ignored if 'deleted_item_sql' is provided => may be NULL)
--- 6. deleted_item_sql – Custom SQL to fetch the value deleted from 'log_field'
+-- 5. deleted_item_sql – Custom SQL to fetch the value deleted from 'log_field'
 DECLARE
     log_collection TEXT := TG_ARGV[0];
     log_collection_id_column TEXT := TG_ARGV[1];
     log_collection_id_sql TEXT := TG_ARGV[2];
     log_field TEXT := TG_ARGV[3];
-    trigger_column TEXT := TG_ARGV[4];
-    deleted_item_column TEXT := TG_ARGV[5];
-    deleted_item_sql TEXT := TG_ARGV[6];
+    deleted_item_column TEXT := TG_ARGV[4];
+    deleted_item_sql TEXT := TG_ARGV[5];
 
     old_hstore hstore := hstore(OLD);
-    old_trigger_value INTEGER;
     log_collection_id INTEGER;
     deleted_item INTEGER;
     new_log_field_value INTEGER[];
     fqid_var TEXT;
 BEGIN
-    -- No need to process deleted instance without field
-    -- Value adding on update is processed in before-trigger
-    old_trigger_value := old_hstore -> trigger_column;
-    IF old_trigger_value IS NULL THEN
-        RETURN NULL;
-    END IF;
-
-    -- Related log_collection item is not updated -> return
+    -- No related log_collection instance -> return
     IF (log_collection_id_sql <> '') THEN
         EXECUTE log_collection_id_sql INTO log_collection_id USING OLD;
     ELSE
@@ -369,6 +350,7 @@ BEGIN
     END IF;
 
     -- No value in column used for log_field -> return
+    -- Value adding on update is processed in before-trigger
     IF (deleted_item_sql <> '') THEN
         EXECUTE deleted_item_sql INTO deleted_item USING OLD;
     ELSE
@@ -4214,17 +4196,17 @@ CREATE TRIGGER tr_log_committee_t_default_meeting_id AFTER INSERT OR UPDATE OF d
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('meeting', 'default_meeting_id', 'default_meeting_for_committee_id');
 
 CREATE TRIGGER tr_log_i_committee_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'user_id', '');
 CREATE TRIGGER tr_log_d_committee_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'meeting_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id', 'user_ids', 'user_id', '');
 CREATE TRIGGER tr_log_i_committee_user_ids_from_nm_committee_manager_idd4a2a53 BEFORE INSERT ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'user_id', '');
 CREATE TRIGGER tr_log_d_committee_user_ids_from_nm_committee_manager_id82dfd00 AFTER DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'committee_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'committee_id', '', 'user_ids', 'user_id', '');
 CREATE TRIGGER tr_log_iu_committee_user_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'id', '');
 CREATE TRIGGER tr_log_ud_committee_user_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'home_committee_id', 'id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('committee', 'home_committee_id', '', 'user_ids', 'id', '');
 
 
 CREATE TRIGGER tr_log_nm_committee_manager_ids_user_t AFTER INSERT OR UPDATE OR DELETE ON nm_committee_manager_ids_user_t
@@ -4427,9 +4409,9 @@ CREATE CONSTRAINT TRIGGER notify_transaction_end AFTER INSERT OR UPDATE OR DELET
 DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION notify_transaction_end();
 
 CREATE TRIGGER tr_log_i_meeting_user_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'user_id', '');
 CREATE TRIGGER tr_log_d_meeting_user_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'meeting_id', 'user_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('meeting', 'meeting_id', '', 'user_ids', 'user_id', '');
 
 CREATE TRIGGER tr_log_meeting_t_reference_projector_id AFTER INSERT OR UPDATE OF reference_projector_id OR DELETE ON meeting_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('projector', 'reference_projector_id', 'used_as_reference_projector_meeting_id');
@@ -4936,25 +4918,25 @@ CREATE TRIGGER tr_log_user_t_gender_id AFTER INSERT OR UPDATE OF gender_id OR DE
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('gender', 'gender_id', 'user_ids');
 
 CREATE TRIGGER tr_log_i_user_committee_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
 CREATE TRIGGER tr_log_d_user_committee_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'meeting_id', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', '', 'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id');
 CREATE TRIGGER tr_log_i_user_committee_ids_from_nm_committee_manager_id3c34791 BEFORE INSERT ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', '');
 CREATE TRIGGER tr_log_d_user_committee_ids_from_nm_committee_manager_id8cfd923 AFTER DELETE ON nm_committee_manager_ids_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', 'committee_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'committee_ids', 'committee_id', '');
 CREATE TRIGGER tr_log_iu_user_committee_ids_from_user_t BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', '');
 CREATE TRIGGER tr_log_ud_user_committee_ids_from_user_t AFTER UPDATE OF home_committee_id OR DELETE ON user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', 'home_committee_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'id', '', 'committee_ids', 'home_committee_id', '');
 
 CREATE TRIGGER tr_log_user_t_home_committee_id AFTER INSERT OR UPDATE OF home_committee_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('committee', 'home_committee_id', 'native_user_ids');
 
 CREATE TRIGGER tr_log_i_user_meeting_ids_from_meeting_user_t BEFORE INSERT ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_iu_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'meeting_id', '');
 CREATE TRIGGER tr_log_d_user_meeting_ids_from_meeting_user_t AFTER DELETE ON meeting_user_t
-FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'user_id', 'meeting_id', '');
+FOR EACH ROW EXECUTE FUNCTION log_ud_modified_calculated_id_array_field('user', 'user_id', '', 'meeting_ids', 'meeting_id', '');
 
 CREATE TRIGGER tr_log_user_t_organization_id AFTER INSERT OR UPDATE OF organization_id OR DELETE ON user_t
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('organization', 'organization_id', 'user_ids');

--- a/dev/sql/schema_relational.sql
+++ b/dev/sql/schema_relational.sql
@@ -378,7 +378,7 @@ BEGIN
     END IF;
 
     EXECUTE format('SELECT %I from "%I" where id = %L', fk_field, foreign_table, foreign_id) INTO new_fk_field_value;
-    IF new_fk_field_value IS NOT NULL AND NOT (log_value = ANY(new_fk_field_value)) THEN
+    IF new_fk_field_value IS NULL OR NOT (log_value = ANY(new_fk_field_value)) THEN
         fqid_var := foreign_table || '/' || foreign_id;
         CALL log_field_change('update', fqid_var, ARRAY[fk_field]);
     END IF;
@@ -5505,22 +5505,10 @@ FOR EACH ROW EXECUTE FUNCTION check_equals('vote', 'option', 'option_id', 'meeti
 
 -- TODO: ensure all these names are unique
 --
--- CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
--- BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
--- FOR EACH ROW
--- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
---     'committee',
---     'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
---     'user_ids',
---     'meeting_id',
---     'user_id',
---     ''
--- );
-
-CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
-AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_meeting_user_t
+BEFORE INSERT OR UPDATE OF meeting_id, user_id ON meeting_user_t
 FOR EACH ROW
-EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+EXECUTE FUNCTION iu_log_modified_calculated_array_field(
     'committee',
     'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',
     'user_ids',
@@ -5529,18 +5517,30 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
     ''
 );
 
+CREATE TRIGGER tr_ud_log_committee_user_ids_from_meeting_user_t
+AFTER UPDATE OF meeting_id, user_id OR DELETE ON meeting_user_t
+FOR EACH ROW
+EXECUTE FUNCTION ud_log_modified_calculated_array_field(
+    'committee',                                                      -- foreign_table
+    'SELECT committee_id FROM meeting_t WHERE id = ($1).meeting_id',  -- foreign_id_sql
+    'user_ids',                                                       -- fk_field
+    'meeting_id',                                                     -- own_column
+    'user_id',                                                        -- column_with_log_data
+    ''                                                                -- log_data_sql
+);
+
 --
--- CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
--- BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
--- FOR EACH ROW
--- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
---     'committee',
---     '',
---     'user_ids',
---     'committee_id',
---     'user_id',
---     ''
--- );
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_nm_committee_manager_ids_user_t
+BEFORE INSERT OR UPDATE ON nm_committee_manager_ids_user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+    'committee',
+    '',
+    'user_ids',
+    'committee_id',
+    'user_id',
+    ''
+);
 
 CREATE TRIGGER tr_ud_log_committee_user_ids_from_nm_committee_manager_ids_user_t
 AFTER UPDATE OR DELETE ON nm_committee_manager_ids_user_t
@@ -5555,17 +5555,17 @@ EXECUTE FUNCTION ud_log_modified_calculated_array_field(
 );
 
 --
--- CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
--- BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
--- FOR EACH ROW
--- EXECUTE FUNCTION iu_log_modified_calculated_array_field(
---     'committee',
---     '',
---     'user_ids',
---     'home_committee_id',
---     'id',
---     ''
--- );
+CREATE TRIGGER tr_iu_log_committee_user_ids_from_user_t
+BEFORE INSERT OR UPDATE OF home_committee_id ON user_t
+FOR EACH ROW
+EXECUTE FUNCTION iu_log_modified_calculated_array_field(
+    'committee',
+    '',
+    'user_ids',
+    'home_committee_id',
+    'id',
+    ''
+);
 
 CREATE TRIGGER tr_ud_log_committee_user_ids_from_user_t
 AFTER UPDATE OF home_committee_id OR DELETE ON user_t

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -146,6 +146,7 @@ class GenerateCodeBlocks:
             "sequence_scope",
             # "on_delete", # must have other name then the key-value-store one
             "sql",
+            "log_triggers_data",
             "equal_fields",
             "unique",
         }
@@ -711,6 +712,17 @@ class GenerateCodeBlocks:
                         )
             if sql := fdata.get("sql", ""):
                 text["view"] = sql + ",\n"
+                text["create_trigger_notify"] = (
+                    "\n"
+                    + (
+                        Helper.get_log_calculated_id_array_trigger_definition(
+                            table_name,
+                            fname,
+                            fdata.get("log_triggers_data", {}),
+                        )
+                    )
+                    + "\n"
+                )
             else:
                 foreign_table_column = cast(str, foreign_table_field.column)
                 foreign_table_field_ref_id = cast(str, foreign_table_field.ref_column)
@@ -2381,6 +2393,75 @@ class Helper:
         own_table = HelperGetNames.get_table_name(table_name)
         return f"""CREATE TRIGGER {trigger_name} AFTER INSERT OR UPDATE OF {ref_column} OR DELETE ON {own_table}
 FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{ref_column}', '{updated_field}');\n"""
+
+    @staticmethod
+    def get_log_calculated_id_array_trigger_definition(
+        view_name: str,
+        log_field: str,
+        triggers_data: list[dict[str, str | dict[str, str]]],
+    ) -> str:
+        TRIGGER_TEMPLATE = string.Template(dedent("""\
+            CREATE TRIGGER ${trigger_name} ${trigger_operations} ON ${trigger_table}
+            FOR EACH ROW EXECUTE FUNCTION ${trigger_type}_log_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${trigger_column}', '${changed_item_column}', '${changed_item_sql}');
+            """))
+        processed_tables: dict[str, int] = {}
+        parts: list[str] = []
+
+        subst_base = {
+            "view_name": view_name,
+            "log_field": log_field,
+        }
+
+        for data in triggers_data:
+            trigger_on = cast(dict[str, str], data.get("define_trigger_on", {}))
+            log_collection_id = cast(dict[str, str], data.get("log_collection_id", {}))
+            log_value = cast(dict[str, str], data.get("log_value", {}))
+
+            trigger_table = trigger_on["table"]
+            columns = trigger_on.get("update_columns")
+
+            if trigger_table not in processed_tables:
+                processed_tables[trigger_table] = 1
+                unique_index = None
+            else:
+                processed_tables[trigger_table] += 1
+                unique_index = processed_tables[trigger_table]
+
+            trigger_columns_iu = f" OR UPDATE OF {columns}" if columns else ""
+            trigger_columns_ud = f" UPDATE OF {columns} OR" if columns else ""
+            trigger_name_iu, trigger_name_ud = (
+                HelperGetNames.get_log_calculated_id_array_trigger_names(
+                    view_name, log_field, trigger_table, bool(columns), unique_index
+                )
+            )
+
+            subst_common = {
+                **subst_base,
+                "trigger_table": trigger_table,
+                "log_collection_id_column": log_collection_id.get("column") or "",
+                "log_collection_id_sql": log_collection_id.get("sql") or "",
+                "trigger_column": data["relational_column"],
+                "changed_item_column": log_value.get("column") or "",
+                "changed_item_sql": log_value.get("sql") or "",
+            }
+            subst_iu = {
+                **subst_common,
+                "trigger_type": "iu",
+                "trigger_name": trigger_name_iu,
+                "trigger_operations": f"BEFORE INSERT{trigger_columns_iu}",
+            }
+
+            subst_ud = {
+                **subst_common,
+                "trigger_type": "ud",
+                "trigger_name": trigger_name_ud,
+                "trigger_operations": f"AFTER{trigger_columns_ud} DELETE",
+            }
+
+            parts.append(TRIGGER_TEMPLATE.substitute(subst_iu))
+            parts.append(TRIGGER_TEMPLATE.substitute(subst_ud))
+
+        return "".join(parts)
 
     @staticmethod
     def get_nm_table_for_n_m_relation_lists(

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -440,14 +440,10 @@ class GenerateCodeBlocks:
     def get_log_calculated_id_array_trigger_params(type_: str) -> dict[str, str]:
         if type_ == "iu":
             hstore_type = "new"
-            comments = """\
-            -- No need to process new instance without field
-                -- Value deletion on update is processed in after-trigger"""
+            comment = "-- Value deletion on update is processed in after-trigger"
         else:
             hstore_type = "old"
-            comments = """\
-            -- No need to process deleted instance without field
-                -- Value adding on update is processed in before-trigger"""
+            comment = "-- Value adding on update is processed in before-trigger"
         return {
             "trigger_type": type_,
             "changed_item_state": "added" if type_ == "iu" else "deleted",
@@ -459,7 +455,7 @@ class GenerateCodeBlocks:
             "fetched_log_value_state": "old" if type_ == "iu" else "new",
             "trigger_return_value": "NEW" if type_ == "iu" else "NULL",
             "instance_state": "new" if type_ == "iu" else "deleted",
-            "comments": dedent(comments),
+            "comment": comment,
         }
 
     @classmethod
@@ -1999,33 +1995,24 @@ class Helper:
             --    (ignored if 'log_collection_id_sql' is provided => may be NULL)
             -- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
             -- 3. log_field – Field to be logged
-            -- 4. trigger_column – Column whose change triggers logging
-            -- 5. ${changed_item_state}_item_column – Column used to fetch the value ${changed_item_state_phrase} 'log_field'
+            -- 4. ${changed_item_state}_item_column – Column used to fetch the value ${changed_item_state_phrase} 'log_field'
             --    (ignored if '${changed_item_state}_item_sql' is provided => may be NULL)
-            -- 6. ${changed_item_state}_item_sql – Custom SQL to fetch the value ${changed_item_state_phrase} 'log_field'
+            -- 5. ${changed_item_state}_item_sql – Custom SQL to fetch the value ${changed_item_state_phrase} 'log_field'
             DECLARE
                 log_collection TEXT := TG_ARGV[0];
                 log_collection_id_column TEXT := TG_ARGV[1];
                 log_collection_id_sql TEXT := TG_ARGV[2];
                 log_field TEXT := TG_ARGV[3];
-                trigger_column TEXT := TG_ARGV[4];
-                ${changed_item_state}_item_column TEXT := TG_ARGV[5];
-                ${changed_item_state}_item_sql TEXT := TG_ARGV[6];
+                ${changed_item_state}_item_column TEXT := TG_ARGV[4];
+                ${changed_item_state}_item_sql TEXT := TG_ARGV[5];
 
                 ${hstore_type}_hstore hstore := hstore(${hstore});
-                ${hstore_type}_trigger_value INTEGER;
                 log_collection_id INTEGER;
                 ${changed_item_state}_item INTEGER;
                 ${fetched_log_value_state}_log_field_value INTEGER[];
                 fqid_var TEXT;
             BEGIN
-                ${comments}
-                ${hstore_type}_trigger_value := ${hstore_type}_hstore -> trigger_column;
-                IF ${hstore_type}_trigger_value IS NULL THEN
-                    RETURN ${trigger_return_value};
-                END IF;
-
-                -- Related log_collection item is not updated -> return
+                -- No related log_collection instance -> return
                 IF (log_collection_id_sql <> '') THEN
                     EXECUTE log_collection_id_sql INTO log_collection_id USING ${hstore};
                 ELSE
@@ -2037,6 +2024,7 @@ class Helper:
                 END IF;
 
                 -- No value in column used for log_field -> return
+                ${comment}
                 IF (${changed_item_state}_item_sql <> '') THEN
                     EXECUTE ${changed_item_state}_item_sql INTO ${changed_item_state}_item USING ${hstore};
                 ELSE
@@ -2413,11 +2401,11 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
     def get_log_calculated_id_array_trigger_definition(
         view_name: str,
         log_field: str,
-        log_triggers: list[dict[str, str | dict[str, str]]],
+        log_triggers: list[dict[str, str]],
     ) -> str:
         TRIGGER_TEMPLATE = string.Template(dedent("""\
             CREATE TRIGGER ${trigger_name} ${trigger_operations} ON ${on_table}
-            FOR EACH ROW EXECUTE FUNCTION log_${trigger_type}_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${relational_column}', '${log_value_column}', '${log_value_sql}');
+            FOR EACH ROW EXECUTE FUNCTION log_${trigger_type}_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${log_value_column}', '${log_value_sql}');
             """))
         processed_tables: dict[str, int] = {}
         parts: list[str] = []
@@ -2458,7 +2446,6 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
                     ]
                 },
                 "on_table": on_table,
-                "relational_column": log_trigger["relational_column"],
             }
             subst_iu = {
                 **subst_common,

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -178,6 +178,7 @@ class GenerateCodeBlocks:
                 )
             )
         pre_code += Helper.FILE_TEMPLATE_CONSTANT_TRIGGERS
+
         for type_ in ["1_1", "1_n", "n_m"]:
             pre_code += Helper.NOT_NULL_TRIGGER_FUNCTION_TEMPLATE.substitute(
                 cls.get_not_null_trigger_params(type_)
@@ -1427,6 +1428,24 @@ class Helper:
         $sequences_trigger$
         LANGUAGE plpgsql;
 
+        CREATE TABLE os_notify_log_t (
+            id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+            operation varchar(32),
+            fqid varchar(256) NOT NULL,
+            updated_fields varchar(63)[],
+            xact_id xid8,
+            timestamp timestamptz,
+            CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
+        );
+
+        CREATE TABLE version (
+            migration_index INTEGER PRIMARY KEY,
+            migration_state TEXT,
+            replace_tables JSONB
+        );
+
+        -- Log functions
+
         CREATE OR REPLACE PROCEDURE log_field_change(
             operation_var TEXT,
             fqid_var TEXT,
@@ -1478,39 +1497,6 @@ class Helper:
             RETURN NULL;  -- returning NULL because AFTER TRIGGER return value is ignored
         END;
         $log_modified_trigger$ LANGUAGE plpgsql;
-
-        CREATE OR REPLACE FUNCTION is_timezone( tz TEXT ) RETURNS BOOLEAN as $$
-        BEGIN
-            PERFORM now() AT TIME ZONE tz;
-            RETURN TRUE;
-        EXCEPTION WHEN invalid_parameter_value THEN
-            RETURN FALSE;
-        END;
-        $$ language plpgsql STABLE;
-
-        CREATE FUNCTION check_unique_ids_pair()
-        RETURNS trigger
-        AS $unique_ids_pair_trigger$
-        -- usage with 1 parameter IN TRIGGER DEFINITION:
-        -- base_column_name: name of write fields before adding numeric suffixes
-        -- Guards against mirrored duplicates by skipping one of the pairs.
-        DECLARE
-            base_column_name text;
-            value_1 integer;
-            value_2 integer;
-        BEGIN
-            base_column_name := TG_ARGV[0];
-            value_1 := hstore(NEW) -> (base_column_name || '_1');
-            value_2 := hstore(NEW) -> (base_column_name || '_2');
-
-            IF (value_1 > value_2) THEN
-                RETURN NULL;
-            END IF;
-
-            RETURN NEW;
-        END;
-        $unique_ids_pair_trigger$
-        LANGUAGE plpgsql;
 
         CREATE FUNCTION notify_transaction_end() RETURNS trigger AS $notify_trigger$
         DECLARE
@@ -1579,24 +1565,43 @@ class Helper:
             RETURN NULL;  -- returning NULL because AFTER TRIGGER return value is ignored
         END;
         $log_modified_related_trigger$ LANGUAGE plpgsql;
-
-        CREATE TABLE os_notify_log_t (
-            id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-            operation varchar(32),
-            fqid varchar(256) NOT NULL,
-            updated_fields varchar(63)[],
-            xact_id xid8,
-            timestamp timestamptz,
-            CONSTRAINT unique_fqid_xact_id_operation UNIQUE (operation,fqid,xact_id)
-        );
-
-        CREATE TABLE version (
-            migration_index INTEGER PRIMARY KEY,
-            migration_state TEXT,
-            replace_tables JSONB
-        );
     """)
-    FILE_TEMPLATE_CONSTANT_TRIGGERS = dedent("""\n
+    FILE_TEMPLATE_CONSTANT_TRIGGERS = dedent("""
+        -- Validation triggers
+
+        CREATE OR REPLACE FUNCTION is_timezone( tz TEXT ) RETURNS BOOLEAN as $$
+        BEGIN
+            PERFORM now() AT TIME ZONE tz;
+            RETURN TRUE;
+        EXCEPTION WHEN invalid_parameter_value THEN
+            RETURN FALSE;
+        END;
+        $$ language plpgsql STABLE;
+
+        CREATE FUNCTION check_unique_ids_pair()
+        RETURNS trigger
+        AS $unique_ids_pair_trigger$
+        -- usage with 1 parameter IN TRIGGER DEFINITION:
+        -- base_column_name: name of write fields before adding numeric suffixes
+        -- Guards against mirrored duplicates by skipping one of the pairs.
+        DECLARE
+            base_column_name text;
+            value_1 integer;
+            value_2 integer;
+        BEGIN
+            base_column_name := TG_ARGV[0];
+            value_1 := hstore(NEW) -> (base_column_name || '_1');
+            value_2 := hstore(NEW) -> (base_column_name || '_2');
+
+            IF (value_1 > value_2) THEN
+                RETURN NULL;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $unique_ids_pair_trigger$
+        LANGUAGE plpgsql;
+
         CREATE OR REPLACE FUNCTION prevent_writes() RETURNS trigger AS $read_only_trigger$
         BEGIN
             RAISE EXCEPTION 'Table % is currently read-only.', TG_TABLE_NAME;

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -170,6 +170,13 @@ class GenerateCodeBlocks:
         im_table_code = ""
         errors: list[str] = []
 
+        for type_ in ["iu", "ud"]:
+            pre_code += (
+                Helper.LOG_CALCULATED_ID_ARRAY_TRIGGER_FUNCTION_TEMPLATE.substitute(
+                    cls.get_log_calculated_id_array_trigger_params(type_)
+                )
+            )
+        pre_code += Helper.FILE_TEMPLATE_CONSTANT_TRIGGERS
         for type_ in ["1_1", "1_n", "n_m"]:
             pre_code += Helper.NOT_NULL_TRIGGER_FUNCTION_TEMPLATE.substitute(
                 cls.get_not_null_trigger_params(type_)
@@ -425,6 +432,32 @@ class GenerateCodeBlocks:
                 if type_ == "n_m"
                 else "OLD.id"
             ),
+        }
+
+    @staticmethod
+    def get_log_calculated_id_array_trigger_params(type_: str) -> dict[str, str]:
+        if type_ == "iu":
+            primary_hstore = "new"
+            comments = """\
+            -- No need to process new instance without field
+                -- Value deletion on update is processed in after-trigger"""
+        else:
+            primary_hstore = "old"
+            comments = """\
+            -- No need to process deleted instance without field
+                -- Value adding on update is processed in before-trigger"""
+        return {
+            "trigger_type": type_,
+            "changed_item_state": "added" if type_ == "iu" else "deleted",
+            "changed_item_state_phrase": (
+                "added to" if type_ == "iu" else "deleted from"
+            ),
+            "primary_hstore": primary_hstore,
+            "primary_hstore_uppercase": primary_hstore.upper(),
+            "secondary_hstore": "old" if type_ == "iu" else "new",
+            "trigger_return_value": "NEW" if type_ == "iu" else "NULL",
+            "instance_state": "new" if type_ == "iu" else "deleted",
+            "comments": dedent(comments),
         }
 
     @classmethod
@@ -1540,7 +1573,8 @@ class Helper:
             migration_state TEXT,
             replace_tables JSONB
         );
-
+    """)
+    FILE_TEMPLATE_CONSTANT_TRIGGERS = dedent("""\n
         CREATE OR REPLACE FUNCTION prevent_writes() RETURNS trigger AS $read_only_trigger$
         BEGIN
             RAISE EXCEPTION 'Table % is currently read-only.', TG_TABLE_NAME;
@@ -1929,6 +1963,74 @@ class Helper:
         $check_equals_meeting_id_for_meeting$ LANGUAGE plpgsql;
 
         """)
+    LOG_CALCULATED_ID_ARRAY_TRIGGER_FUNCTION_TEMPLATE = string.Template(dedent("""
+            CREATE OR REPLACE FUNCTION ${trigger_type}_log_modified_calculated_id_array_field()
+            RETURNS trigger AS $$log_modified_calculated_id_array_field_trigger$$
+            -- Expects in this order:
+            -- 0. log_collection – Target collection for the log entry
+            -- 1. log_collection_id_column – Column used to fetch the 'log_collection' id
+            --    (ignored if 'log_collection_id_sql' is provided => may be NULL)
+            -- 2. log_collection_id_sql – Custom SQL to fetch the 'log_collection' id
+            -- 3. log_field – Field to be logged
+            -- 4. trigger_column – Column whose change triggers logging
+            -- 5. ${changed_item_state}_item_column – Column used to fetch the value ${changed_item_state_phrase} 'log_field'
+            --    (ignored if '${changed_item_state}_item_sql' is provided => may be NULL)
+            -- 6. ${changed_item_state}_item_sql – Custom SQL to fetch the value ${changed_item_state_phrase} 'log_field'
+            DECLARE
+                log_collection TEXT := TG_ARGV[0];
+                log_collection_id_column TEXT := TG_ARGV[1];
+                log_collection_id_sql TEXT := TG_ARGV[2];
+                log_field TEXT := TG_ARGV[3];
+                trigger_column TEXT := TG_ARGV[4];
+                ${changed_item_state}_item_column TEXT := TG_ARGV[5];
+                ${changed_item_state}_item_sql TEXT := TG_ARGV[6];
+
+                ${primary_hstore}_hstore hstore := hstore(${primary_hstore_uppercase});
+                ${primary_hstore}_trigger_value INTEGER;
+                log_collection_id INTEGER;
+                ${changed_item_state}_item INTEGER;
+                ${secondary_hstore}_log_field_value INTEGER[];
+                fqid_var TEXT;
+            BEGIN
+                ${comments}
+                ${primary_hstore}_trigger_value := ${primary_hstore}_hstore -> trigger_column;
+                IF ${primary_hstore}_trigger_value IS NULL THEN
+                    RETURN ${trigger_return_value};
+                END IF;
+
+                -- Related log_collection item is not updated -> return
+                IF (log_collection_id_sql <> '') THEN
+                    EXECUTE log_collection_id_sql INTO log_collection_id USING ${primary_hstore_uppercase};
+                ELSE
+                    log_collection_id := ${primary_hstore}_hstore -> log_collection_id_column;
+                END IF;
+
+                IF log_collection_id IS NULL THEN
+                    RETURN ${trigger_return_value};
+                END IF;
+
+                -- No value in column used for log_field -> return
+                IF (${changed_item_state}_item_sql <> '') THEN
+                    EXECUTE ${changed_item_state}_item_sql INTO ${changed_item_state}_item USING ${primary_hstore_uppercase};
+                ELSE
+                    ${changed_item_state}_item := ${primary_hstore}_hstore -> ${changed_item_state}_item_column;
+                END IF;
+
+                IF ${changed_item_state}_item IS NULL THEN
+                    RETURN ${trigger_return_value};
+                END IF;
+
+                -- Add log entry only if log_field value actually changes
+                EXECUTE format('SELECT %I from %I where id = %L', log_field, log_collection, log_collection_id) INTO ${secondary_hstore}_log_field_value;
+                IF ${secondary_hstore}_log_field_value IS NULL OR NOT (${changed_item_state}_item = ANY(${secondary_hstore}_log_field_value)) THEN
+                    fqid_var := log_collection || '/' || log_collection_id;
+                    CALL log_field_change('update', fqid_var, ARRAY[log_field]);
+                END IF;
+
+                RETURN ${trigger_return_value};
+            END;
+            $$log_modified_calculated_id_array_field_trigger$$ LANGUAGE plpgsql;
+        """))
     NOT_NULL_TRIGGER_FUNCTION_TEMPLATE = string.Template(dedent("""
             CREATE FUNCTION check_not_null_for_${trigger_type}() RETURNS trigger AS $$not_null_trigger$$
             ${docstring}

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -1986,7 +1986,7 @@ class Helper:
 
         """)
     LOG_CALCULATED_ID_ARRAY_TRIGGER_FUNCTION_TEMPLATE = string.Template(dedent("""
-            CREATE OR REPLACE FUNCTION ${trigger_type}_log_modified_calculated_id_array_field()
+            CREATE OR REPLACE FUNCTION log_${trigger_type}_modified_calculated_id_array_field()
             RETURNS trigger AS $$log_modified_calculated_id_array_field_trigger$$
             -- Expects in this order:
             -- 0. log_collection – Target collection for the log entry
@@ -2412,7 +2412,7 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
     ) -> str:
         TRIGGER_TEMPLATE = string.Template(dedent("""\
             CREATE TRIGGER ${trigger_name} ${trigger_operations} ON ${trigger_table}
-            FOR EACH ROW EXECUTE FUNCTION ${trigger_type}_log_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${trigger_column}', '${changed_item_column}', '${changed_item_sql}');
+            FOR EACH ROW EXECUTE FUNCTION log_${trigger_type}_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${trigger_column}', '${changed_item_column}', '${changed_item_sql}');
             """))
         processed_tables: dict[str, int] = {}
         parts: list[str] = []

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -439,12 +439,12 @@ class GenerateCodeBlocks:
     @staticmethod
     def get_log_calculated_id_array_trigger_params(type_: str) -> dict[str, str]:
         if type_ == "iu":
-            primary_hstore = "new"
+            hstore_type = "new"
             comments = """\
             -- No need to process new instance without field
                 -- Value deletion on update is processed in after-trigger"""
         else:
-            primary_hstore = "old"
+            hstore_type = "old"
             comments = """\
             -- No need to process deleted instance without field
                 -- Value adding on update is processed in before-trigger"""
@@ -454,9 +454,9 @@ class GenerateCodeBlocks:
             "changed_item_state_phrase": (
                 "added to" if type_ == "iu" else "deleted from"
             ),
-            "primary_hstore": primary_hstore,
-            "primary_hstore_uppercase": primary_hstore.upper(),
-            "secondary_hstore": "old" if type_ == "iu" else "new",
+            "hstore_type": hstore_type,
+            "hstore": hstore_type.upper(),
+            "fetched_log_value_state": "old" if type_ == "iu" else "new",
             "trigger_return_value": "NEW" if type_ == "iu" else "NULL",
             "instance_state": "new" if type_ == "iu" else "deleted",
             "comments": dedent(comments),
@@ -2012,24 +2012,24 @@ class Helper:
                 ${changed_item_state}_item_column TEXT := TG_ARGV[5];
                 ${changed_item_state}_item_sql TEXT := TG_ARGV[6];
 
-                ${primary_hstore}_hstore hstore := hstore(${primary_hstore_uppercase});
-                ${primary_hstore}_trigger_value INTEGER;
+                ${hstore_type}_hstore hstore := hstore(${hstore});
+                ${hstore_type}_trigger_value INTEGER;
                 log_collection_id INTEGER;
                 ${changed_item_state}_item INTEGER;
-                ${secondary_hstore}_log_field_value INTEGER[];
+                ${fetched_log_value_state}_log_field_value INTEGER[];
                 fqid_var TEXT;
             BEGIN
                 ${comments}
-                ${primary_hstore}_trigger_value := ${primary_hstore}_hstore -> trigger_column;
-                IF ${primary_hstore}_trigger_value IS NULL THEN
+                ${hstore_type}_trigger_value := ${hstore_type}_hstore -> trigger_column;
+                IF ${hstore_type}_trigger_value IS NULL THEN
                     RETURN ${trigger_return_value};
                 END IF;
 
                 -- Related log_collection item is not updated -> return
                 IF (log_collection_id_sql <> '') THEN
-                    EXECUTE log_collection_id_sql INTO log_collection_id USING ${primary_hstore_uppercase};
+                    EXECUTE log_collection_id_sql INTO log_collection_id USING ${hstore};
                 ELSE
-                    log_collection_id := ${primary_hstore}_hstore -> log_collection_id_column;
+                    log_collection_id := ${hstore_type}_hstore -> log_collection_id_column;
                 END IF;
 
                 IF log_collection_id IS NULL THEN
@@ -2038,9 +2038,9 @@ class Helper:
 
                 -- No value in column used for log_field -> return
                 IF (${changed_item_state}_item_sql <> '') THEN
-                    EXECUTE ${changed_item_state}_item_sql INTO ${changed_item_state}_item USING ${primary_hstore_uppercase};
+                    EXECUTE ${changed_item_state}_item_sql INTO ${changed_item_state}_item USING ${hstore};
                 ELSE
-                    ${changed_item_state}_item := ${primary_hstore}_hstore -> ${changed_item_state}_item_column;
+                    ${changed_item_state}_item := ${hstore_type}_hstore -> ${changed_item_state}_item_column;
                 END IF;
 
                 IF ${changed_item_state}_item IS NULL THEN
@@ -2048,8 +2048,8 @@ class Helper:
                 END IF;
 
                 -- Add log entry only if log_field value actually changes
-                EXECUTE format('SELECT %I from %I where id = %L', log_field, log_collection, log_collection_id) INTO ${secondary_hstore}_log_field_value;
-                IF ${secondary_hstore}_log_field_value IS NULL OR NOT (${changed_item_state}_item = ANY(${secondary_hstore}_log_field_value)) THEN
+                EXECUTE format('SELECT %I from %I where id = %L', log_field, log_collection, log_collection_id) INTO ${fetched_log_value_state}_log_field_value;
+                IF ${fetched_log_value_state}_log_field_value IS NULL OR NOT (${changed_item_state}_item = ANY(${fetched_log_value_state}_log_field_value)) THEN
                     fqid_var := log_collection || '/' || log_collection_id;
                     CALL log_field_change('update', fqid_var, ARRAY[log_field]);
                 END IF;
@@ -2413,11 +2413,11 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
     def get_log_calculated_id_array_trigger_definition(
         view_name: str,
         log_field: str,
-        triggers_data: list[dict[str, str | dict[str, str]]],
+        log_triggers: list[dict[str, str | dict[str, str]]],
     ) -> str:
         TRIGGER_TEMPLATE = string.Template(dedent("""\
-            CREATE TRIGGER ${trigger_name} ${trigger_operations} ON ${trigger_table}
-            FOR EACH ROW EXECUTE FUNCTION log_${trigger_type}_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${trigger_column}', '${changed_item_column}', '${changed_item_sql}');
+            CREATE TRIGGER ${trigger_name} ${trigger_operations} ON ${on_table}
+            FOR EACH ROW EXECUTE FUNCTION log_${trigger_type}_modified_calculated_id_array_field('${view_name}', '${log_collection_id_column}', '${log_collection_id_sql}', '${log_field}', '${relational_column}', '${log_value_column}', '${log_value_sql}');
             """))
         processed_tables: dict[str, int] = {}
         parts: list[str] = []
@@ -2427,33 +2427,38 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
             "log_field": log_field,
         }
 
-        for data in triggers_data:
-            trigger_table = data["on_table"]
-            columns = data.get("on_columns")
+        for log_trigger in log_triggers:
+            on_table = log_trigger["on_table"]
+            on_columns = log_trigger.get("on_columns")
 
-            if trigger_table not in processed_tables:
-                processed_tables[trigger_table] = 1
+            if on_table not in processed_tables:
+                processed_tables[on_table] = 1
                 unique_index = None
             else:
-                processed_tables[trigger_table] += 1
-                unique_index = processed_tables[trigger_table]
+                processed_tables[on_table] += 1
+                unique_index = processed_tables[on_table]
 
-            trigger_columns_iu = f" OR UPDATE OF {columns}" if columns else ""
-            trigger_columns_ud = f" UPDATE OF {columns} OR" if columns else ""
+            trigger_columns_iu = f" OR UPDATE OF {on_columns}" if on_columns else ""
+            trigger_columns_ud = f" UPDATE OF {on_columns} OR" if on_columns else ""
             trigger_name_iu, trigger_name_ud = (
                 HelperGetNames.get_log_calculated_id_array_trigger_names(
-                    view_name, log_field, trigger_table, bool(columns), unique_index
+                    view_name, log_field, on_table, bool(on_columns), unique_index
                 )
             )
 
             subst_common = {
                 **subst_base,
-                "trigger_table": trigger_table,
-                "log_collection_id_column": data.get("log_collection_id_column") or "",
-                "log_collection_id_sql": data.get("log_collection_id_sql") or "",
-                "trigger_column": data["relational_column"],
-                "changed_item_column": data.get("log_value_column") or "",
-                "changed_item_sql": data.get("log_value_sql") or "",
+                **{
+                    attr: (log_trigger.get(attr) or "")
+                    for attr in [
+                        "log_collection_id_sql",
+                        "log_collection_id_column",
+                        "log_value_sql",
+                        "log_value_column",
+                    ]
+                },
+                "on_table": on_table,
+                "relational_column": log_trigger["relational_column"],
             }
             subst_iu = {
                 **subst_common,

--- a/dev/src/generate_sql_schema.py
+++ b/dev/src/generate_sql_schema.py
@@ -146,7 +146,7 @@ class GenerateCodeBlocks:
             "sequence_scope",
             # "on_delete", # must have other name then the key-value-store one
             "sql",
-            "log_triggers_data",
+            "log_triggers",
             "equal_fields",
             "unique",
         }
@@ -718,7 +718,7 @@ class GenerateCodeBlocks:
                         Helper.get_log_calculated_id_array_trigger_definition(
                             table_name,
                             fname,
-                            fdata.get("log_triggers_data", {}),
+                            fdata.get("log_triggers", {}),
                         )
                     )
                     + "\n"
@@ -2423,12 +2423,8 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
         }
 
         for data in triggers_data:
-            trigger_on = cast(dict[str, str], data.get("define_trigger_on", {}))
-            log_collection_id = cast(dict[str, str], data.get("log_collection_id", {}))
-            log_value = cast(dict[str, str], data.get("log_value", {}))
-
-            trigger_table = trigger_on["table"]
-            columns = trigger_on.get("update_columns")
+            trigger_table = data["on_table"]
+            columns = data.get("on_columns")
 
             if trigger_table not in processed_tables:
                 processed_tables[trigger_table] = 1
@@ -2448,11 +2444,11 @@ FOR EACH ROW EXECUTE FUNCTION log_modified_related_models('{foreign_table}', '{r
             subst_common = {
                 **subst_base,
                 "trigger_table": trigger_table,
-                "log_collection_id_column": log_collection_id.get("column") or "",
-                "log_collection_id_sql": log_collection_id.get("sql") or "",
+                "log_collection_id_column": data.get("log_collection_id_column") or "",
+                "log_collection_id_sql": data.get("log_collection_id_sql") or "",
                 "trigger_column": data["relational_column"],
-                "changed_item_column": log_value.get("column") or "",
-                "changed_item_sql": log_value.get("sql") or "",
+                "changed_item_column": data.get("log_value_column") or "",
+                "changed_item_sql": data.get("log_value_sql") or "",
             }
             subst_iu = {
                 **subst_common,

--- a/dev/src/helper_get_names.py
+++ b/dev/src/helper_get_names.py
@@ -387,6 +387,52 @@ class HelperGetNames:
 
     @staticmethod
     @max_length
+    def get_log_calculated_id_array_trigger_name_iu(
+        table_name: str,
+        column_name: str,
+        trigger_table: str,
+        update: bool,
+        unique_index: str,
+    ) -> str:
+        """
+        Gets the name of the trigger for logging changes on calculated fields
+        on insert and update operations on the related table.
+        """
+        return f"tr_i{'u' if update else ''}_log_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
+
+    @staticmethod
+    @max_length
+    def get_log_calculated_id_array_trigger_name_ud(
+        table_name: str,
+        column_name: str,
+        trigger_table: str,
+        update: bool,
+        unique_index: str,
+    ) -> str:
+        """
+        Gets the name of the trigger for logging changes on calculated fields
+        on update and delete operations on the related table.
+        """
+        return f"tr_{'u' if update else ''}d_log_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
+
+    @staticmethod
+    def get_log_calculated_id_array_trigger_names(
+        table_name: str,
+        column_name: str,
+        trigger_table: str,
+        update: bool,
+        unique_index: int | None = None,
+    ) -> tuple[str, str]:
+        """Gets the named of the triggers for logging changes on calculated fields"""
+        index_string = f"_{unique_index}" if unique_index is not None else ""
+        return HelperGetNames.get_log_calculated_id_array_trigger_name_iu(
+            table_name, column_name, trigger_table, update, index_string
+        ), HelperGetNames.get_log_calculated_id_array_trigger_name_ud(
+            table_name, column_name, trigger_table, update, index_string
+        )
+
+    @staticmethod
+    @max_length
     def get_timezone_constraint_name(table_name: str, field_name: str) -> str:
         """gets the name of the constraint for timezone fields"""
         return f"timezone_{table_name}_{field_name}"

--- a/dev/src/helper_get_names.py
+++ b/dev/src/helper_get_names.py
@@ -418,7 +418,7 @@ class HelperGetNames:
         Gets the name of the trigger for logging changes on calculated fields
         on insert and update operations on the related table.
         """
-        return f"tr_i{'u' if update else ''}_log_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
+        return f"tr_log_i{'u' if update else ''}_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
 
     @staticmethod
     @max_length
@@ -433,7 +433,7 @@ class HelperGetNames:
         Gets the name of the trigger for logging changes on calculated fields
         on update and delete operations on the related table.
         """
-        return f"tr_{'u' if update else ''}d_log_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
+        return f"tr_log_{'u' if update else ''}d_{table_name}_{column_name}_from_{trigger_table}{unique_index}"
 
     @staticmethod
     def get_log_calculated_id_array_trigger_names(

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -324,6 +324,9 @@ class Checker:
             if nested and type in ("relation", "relation-list"):
                 valid_attributes.append("enum")
             valid_attributes.extend(("reference", "deferred", "sql"))
+            if field.get("sql"):
+                valid_attributes.append("log_triggers_data")
+                self.check_log_triggers_data(collectionfield, field)
             if "default" in field and field_name == "organization_id":
                 # added as a workaround to allow defaulting to the ONE_ORGANIZATION
                 print(f"Default in {collection}/{field_name} temporarily allowed.")
@@ -566,6 +569,57 @@ class Checker:
         if from_collectionfield not in to_unified:
             return f"{from_collectionfield} points to {to_collectionfield}, but {to_collectionfield} does not point back."
         return None
+
+    def check_log_triggers_data(
+        self, collectionfield: str, field: dict[str, Any]
+    ) -> None:
+        if not (data_list := field.get("log_triggers_data")):
+            self.errors.append(
+                f"For {collectionfield} 'log_triggers_data' attribute must be defined because it has 'sql' attribute."
+            )
+            return
+
+        for i in range(len(data_list)):
+            base_error_message = (
+                f"Error in item {i} of {collectionfield}.log_triggers_data"
+            )
+            data = data_list[i]
+            trigger_table = (data.get("define_trigger_on") or {}).get("table")
+            missing_required_attributes = [
+                attr_name
+                for attr_name in [
+                    "relational_column",
+                    "log_collection_id",
+                    "log_value",
+                ]
+                if attr_name not in data
+            ]
+            if not trigger_table:
+                missing_required_attributes.append("define_trigger_on.table")
+            if missing_required_attributes:
+                self.errors.append(
+                    f"{base_error_message}: some of the required attributes are missing: {', '.join(missing_required_attributes)}."
+                )
+
+            if trigger_table and not trigger_table.endswith("_t"):
+                self.errors.append(
+                    f"{base_error_message}: '{trigger_table}' is not a valid value for 'define_trigger_on.table' (must end with '_t')."
+                )
+
+            for attr_name in ["log_collection_id", "log_value"]:
+                if attr_name not in data:
+                    continue
+                attr_data = data.get(attr_name) or {}
+                sql = attr_data.get("sql")
+                column = attr_data.get("column")
+                if column is None and sql is None:
+                    self.errors.append(
+                        f"{base_error_message}: either 'sql' or 'column' must be defined for log_triggers_data.{attr_name}."
+                    )
+                elif column is not None and sql is not None:
+                    print(
+                        f"For for item {i} of {collectionfield}.log_triggers_data value in '{attr_name}.column' will be ignored because '{attr_name}.sql' is defined."
+                    )
 
     def validate_enum(self, collectionfield: str, enum: Any) -> list[str] | None:
         """

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -570,7 +570,7 @@ class Checker:
             return f"{from_collectionfield} points to {to_collectionfield}, but {to_collectionfield} does not point back."
         return None
 
-    def check_log_triggers(self, collectionfield: str, field: dict[str, Any]) -> None:
+    def check_log_triggers(self, collectionfield: str, field: dict[str, str]) -> None:
         if not (log_triggers := field.get("log_triggers")):
             self.errors.append(
                 f"For {collectionfield} 'log_triggers' attribute must be defined because it has 'sql' attribute."
@@ -580,7 +580,6 @@ class Checker:
         valid_attributes = [
             "on_table",
             "on_columns",
-            "relational_column",
             "log_collection_id_column",
             "log_collection_id_sql",
             "log_value_column",
@@ -589,19 +588,11 @@ class Checker:
         for i in range(len(log_triggers)):
             base_error_message = f"Error in item {i} of {collectionfield}.log_triggers"
             log_trigger = log_triggers[i]
-            missing_required_attributes = [
-                attr_name
-                for attr_name in ["on_table", "relational_column"]
-                if not log_trigger.get(attr_name)
-            ]
-            if missing_required_attributes:
+            if not (on_table := log_trigger.get("on_table")):
                 self.errors.append(
-                    f"{base_error_message}: some of the required attributes are missing: {', '.join(missing_required_attributes)}."
+                    f"{base_error_message}: missing a required attribute 'on_table'."
                 )
-
-            if (on_table := log_trigger.get("on_table")) and not on_table.endswith(
-                "_t"
-            ):
+            elif not on_table.endswith("_t"):
                 self.errors.append(
                     f"{base_error_message}: '{on_table}' is not a valid value for 'on_table' (must end with '_t')."
                 )

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -571,7 +571,7 @@ class Checker:
         return None
 
     def check_log_triggers(self, collectionfield: str, field: dict[str, Any]) -> None:
-        if not (data_list := field.get("log_triggers")):
+        if not (log_triggers := field.get("log_triggers")):
             self.errors.append(
                 f"For {collectionfield} 'log_triggers' attribute must be defined because it has 'sql' attribute."
             )
@@ -586,29 +586,29 @@ class Checker:
             "log_value_column",
             "log_value_sql",
         ]
-        for i in range(len(data_list)):
+        for i in range(len(log_triggers)):
             base_error_message = f"Error in item {i} of {collectionfield}.log_triggers"
-            data = data_list[i]
+            log_trigger = log_triggers[i]
             missing_required_attributes = [
                 attr_name
                 for attr_name in ["on_table", "relational_column"]
-                if not data.get(attr_name)
+                if not log_trigger.get(attr_name)
             ]
             if missing_required_attributes:
                 self.errors.append(
                     f"{base_error_message}: some of the required attributes are missing: {', '.join(missing_required_attributes)}."
                 )
 
-            if (
-                trigger_table := data.get("on_table")
-            ) and not trigger_table.endswith("_t"):
+            if (on_table := log_trigger.get("on_table")) and not on_table.endswith(
+                "_t"
+            ):
                 self.errors.append(
-                    f"{base_error_message}: '{trigger_table}' is not a valid value for 'on_table' (must end with '_t')."
+                    f"{base_error_message}: '{on_table}' is not a valid value for 'on_table' (must end with '_t')."
                 )
 
             for base_attr_name in ["log_collection_id", "log_value"]:
                 values_present = [
-                    bool(data.get(f"{base_attr_name}_{option}"))
+                    bool(log_trigger.get(f"{base_attr_name}_{option}"))
                     for option in ["column", "sql"]
                 ]
                 if not any(values_present):
@@ -620,7 +620,7 @@ class Checker:
                         f"For for item {i} of {collectionfield}.log_triggers value in '{base_attr_name}_column' will be ignored because '{base_attr_name}_sql' is defined."
                     )
 
-            for attr in data.keys():
+            for attr in log_trigger.keys():
                 if attr not in valid_attributes:
                     self.errors.append(
                         f"{base_error_message}: attribute '{attr}' is invalid."

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -576,6 +576,11 @@ class Checker:
                 f"For {collectionfield} 'log_triggers' attribute must be defined because it has 'sql' attribute."
             )
             return
+        elif not isinstance(log_triggers, list):
+            self.errors.append(
+                f"Invalid value for 'log_triggers' of {collectionfield}: must be a list of dictionaries."
+            )
+            return
 
         valid_attributes = [
             "on_table",
@@ -588,6 +593,9 @@ class Checker:
         for i in range(len(log_triggers)):
             base_error_message = f"Error in item {i} of {collectionfield}.log_triggers"
             log_trigger = log_triggers[i]
+            if not isinstance(log_trigger, dict):
+                self.errors.append(f"{base_error_message}: must be a dictionary.")
+                continue
             if not (on_table := log_trigger.get("on_table")):
                 self.errors.append(
                     f"{base_error_message}: missing a required attribute 'on_table'."

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -577,6 +577,15 @@ class Checker:
             )
             return
 
+        valid_attributes = [
+            "on_table",
+            "on_columns",
+            "relational_column",
+            "log_collection_id_column",
+            "log_collection_id_sql",
+            "log_value_column",
+            "log_value_sql",
+        ]
         for i in range(len(data_list)):
             base_error_message = f"Error in item {i} of {collectionfield}.log_triggers"
             data = data_list[i]
@@ -609,6 +618,12 @@ class Checker:
                 elif all(values_present):
                     print(
                         f"For for item {i} of {collectionfield}.log_triggers value in '{base_attr_name}_column' will be ignored because '{base_attr_name}_sql' is defined."
+                    )
+
+            for attr in data.keys():
+                if attr not in valid_attributes:
+                    self.errors.append(
+                        f"{base_error_message}: attribute '{attr}' is invalid."
                     )
 
     def validate_enum(self, collectionfield: str, enum: Any) -> list[str] | None:

--- a/dev/src/validate.py
+++ b/dev/src/validate.py
@@ -325,8 +325,8 @@ class Checker:
                 valid_attributes.append("enum")
             valid_attributes.extend(("reference", "deferred", "sql"))
             if field.get("sql"):
-                valid_attributes.append("log_triggers_data")
-                self.check_log_triggers_data(collectionfield, field)
+                valid_attributes.append("log_triggers")
+                self.check_log_triggers(collectionfield, field)
             if "default" in field and field_name == "organization_id":
                 # added as a workaround to allow defaulting to the ONE_ORGANIZATION
                 print(f"Default in {collection}/{field_name} temporarily allowed.")
@@ -570,55 +570,45 @@ class Checker:
             return f"{from_collectionfield} points to {to_collectionfield}, but {to_collectionfield} does not point back."
         return None
 
-    def check_log_triggers_data(
-        self, collectionfield: str, field: dict[str, Any]
-    ) -> None:
-        if not (data_list := field.get("log_triggers_data")):
+    def check_log_triggers(self, collectionfield: str, field: dict[str, Any]) -> None:
+        if not (data_list := field.get("log_triggers")):
             self.errors.append(
-                f"For {collectionfield} 'log_triggers_data' attribute must be defined because it has 'sql' attribute."
+                f"For {collectionfield} 'log_triggers' attribute must be defined because it has 'sql' attribute."
             )
             return
 
         for i in range(len(data_list)):
-            base_error_message = (
-                f"Error in item {i} of {collectionfield}.log_triggers_data"
-            )
+            base_error_message = f"Error in item {i} of {collectionfield}.log_triggers"
             data = data_list[i]
-            trigger_table = (data.get("define_trigger_on") or {}).get("table")
             missing_required_attributes = [
                 attr_name
-                for attr_name in [
-                    "relational_column",
-                    "log_collection_id",
-                    "log_value",
-                ]
-                if attr_name not in data
+                for attr_name in ["on_table", "relational_column"]
+                if not data.get(attr_name)
             ]
-            if not trigger_table:
-                missing_required_attributes.append("define_trigger_on.table")
             if missing_required_attributes:
                 self.errors.append(
                     f"{base_error_message}: some of the required attributes are missing: {', '.join(missing_required_attributes)}."
                 )
 
-            if trigger_table and not trigger_table.endswith("_t"):
+            if (
+                trigger_table := data.get("on_table")
+            ) and not trigger_table.endswith("_t"):
                 self.errors.append(
-                    f"{base_error_message}: '{trigger_table}' is not a valid value for 'define_trigger_on.table' (must end with '_t')."
+                    f"{base_error_message}: '{trigger_table}' is not a valid value for 'on_table' (must end with '_t')."
                 )
 
-            for attr_name in ["log_collection_id", "log_value"]:
-                if attr_name not in data:
-                    continue
-                attr_data = data.get(attr_name) or {}
-                sql = attr_data.get("sql")
-                column = attr_data.get("column")
-                if column is None and sql is None:
+            for base_attr_name in ["log_collection_id", "log_value"]:
+                values_present = [
+                    bool(data.get(f"{base_attr_name}_{option}"))
+                    for option in ["column", "sql"]
+                ]
+                if not any(values_present):
                     self.errors.append(
-                        f"{base_error_message}: either 'sql' or 'column' must be defined for log_triggers_data.{attr_name}."
+                        f"{base_error_message}: either '{base_attr_name}_sql' or '{base_attr_name}_column' must be defined."
                     )
-                elif column is not None and sql is not None:
+                elif all(values_present):
                     print(
-                        f"For for item {i} of {collectionfield}.log_triggers_data value in '{attr_name}.column' will be ignored because '{attr_name}.sql' is defined."
+                        f"For for item {i} of {collectionfield}.log_triggers value in '{base_attr_name}_column' will be ignored because '{base_attr_name}_sql' is defined."
                     )
 
     def validate_enum(self, collectionfield: str, enum: Any) -> list[str] | None:


### PR DESCRIPTION
Resolves https://github.com/OpenSlides/openslides-meta/issues/445

TODO:
- [x] (needs trigger for constant fields): if both sides of nm-table or all the fields from `define_trigger_on.columns` have `constant: true` + `required: true`, update operation can be excluded from the trigger definition
- [x] Collections validator must check that:
    - [x] If `sql` is defined, `log_triggers_data` is defined too (+ add it to allowed attributes in this case);
    - [x] For `log_collection_id` and `log_value` one of `column` or `sql` is defined;
    - [x] For `define_trigger_on` `table` is defined and ends with '_t';
    - [x] `relational_column` is defined.